### PR TITLE
Optimization of interaction matrix elements

### DIFF
--- a/include/xatu/Exciton.hpp
+++ b/include/xatu/Exciton.hpp
@@ -189,9 +189,6 @@ class Exciton : public System {
         arma::cx_vec atomicToLatticeGauge(const arma::cx_vec&, const arma::rowvec&);
         arma::cx_mat fixGlobalPhase(arma::cx_mat&);
 
-        // Auxiliary routines for Fermi golden rule
-        arma::rowvec findElectronHolePair(const Exciton&, double, std::string, bool);
-
 
     public:
         arma::imat createBasis(const arma::ivec&, const arma::ivec&);
@@ -213,6 +210,9 @@ class Exciton : public System {
         arma::cx_vec ehPairCoefs(double, const arma::vec&, std::string side = "right");
         double fermiGoldenRule(const Exciton&, const arma::cx_vec&, const arma::cx_vec&, double);
         double edgeFermiGoldenRule(const Exciton&, const arma::cx_vec&, double, std::string side = "right", bool increasing = false);
+
+        // Auxiliary routines for Fermi golden rule
+        arma::rowvec findElectronHolePair(const Exciton&, double, std::string, bool);
 };
 
 }

--- a/include/xatu/Result.hpp
+++ b/include/xatu/Result.hpp
@@ -48,6 +48,7 @@ class Result{
         double potentialEnergy(int);
         double bindingEnergy(int, double gap = -1);
         double determineGap();
+        arma::cx_vec spinX(const arma::cx_vec&);
         arma::cx_vec spinX(int);
         arma::mat velocity(int);
         arma::cx_vec velocitySingleParticle(int, int, int, std::string);

--- a/include/xatu/System.hpp
+++ b/include/xatu/System.hpp
@@ -58,6 +58,9 @@ class System : public Crystal{
         void solveBands(arma::rowvec&, arma::vec&, arma::cx_mat&, bool triangular = false) const;
         void solveBands(std::string, bool triangular = false) const;
 
+        /* Modifiers */
+        void addZeeman(double);
+
         /* Expected value of spin components */
         
         double expectedSpinZValue(const arma::cx_vec&);

--- a/include/xatu/System.hpp
+++ b/include/xatu/System.hpp
@@ -58,14 +58,13 @@ class System : public Crystal{
         void solveBands(arma::rowvec&, arma::vec&, arma::cx_mat&, bool triangular = false) const;
         void solveBands(std::string, bool triangular = false) const;
 
-        /* Modifiers */
-        void addZeeman(double);
-
         /* Expected value of spin components */
         
         double expectedSpinZValue(const arma::cx_vec&);
         double expectedSpinYValue(const arma::cx_vec&);
-        double expectedSpinXValue(const arma::cx_vec&);        
+        double expectedSpinXValue(const arma::cx_vec&);      
+
+        arma::cx_vec velocity(const arma::rowvec, int, int) const;  
     
         void initializeSystemAttributes(const SystemConfiguration&);
 

--- a/main/xatu.cpp
+++ b/main/xatu.cpp
@@ -77,7 +77,6 @@ int main(int argc, char* argv[]){
 
     // Init. configurations
     std::unique_ptr<xatu::SystemConfiguration> systemConfig;
-    std::unique_ptr<xatu::CrystalDFTConfiguration> systemDFTConfig; 
     std::unique_ptr<xatu::ExcitonConfiguration> excitonConfig;
 
     if (dftArg.isSet()){
@@ -213,13 +212,8 @@ int main(int argc, char* argv[]){
 
     bool writeAbs = absorptionArg.isSet();
     if(writeAbs){
-        std::string filename_abs = output + ".abs";
-        FILE* textfile_abs = fopen(filename_abs.c_str(), "w");
-
         std::cout << "Writing absorption spectrum fo file... " << std::endl;
         results.writeAbsorptionSpectrum();
-
-        fclose(textfile_abs);
     }
 
     bool writeSpin = spinArg.isSet();

--- a/src/BiRibbon.cpp
+++ b/src/BiRibbon.cpp
@@ -67,7 +67,7 @@ void BiRibbon::initializeConstants(){
 	this->lambda = 1.5;
 
 	// Zeeman term (infinitesimal, only for spin splitting)
-	this->zeeman = 1E-8;
+	this->zeeman = 1E-7;
 
 	// Infinitesimal on-site energy to split edges
 	this->onsiteEdge = 0.0;

--- a/src/Exciton.cpp
+++ b/src/Exciton.cpp
@@ -587,10 +587,27 @@ std::complex<double> Exciton::exactInteractionTermMFT(const arma::cx_vec& coefsK
                                      const arma::cx_vec& coefsK4,
                                      const arma::cx_mat& motifFT){
     
-    arma::cx_vec firstCoefArray = arma::conj(coefsK1) % coefsK3;
+    arma::cx_vec firstCoefArray =  arma::conj(coefsK1) % coefsK3;
     arma::cx_vec secondCoefArray = arma::conj(coefsK2) % coefsK4;
-    std::complex<double> term = arma::dot(firstCoefArray, extendMotifFT(motifFT) * secondCoefArray);
-        
+    /* Old implementation; one below should be faster */
+    // std::complex<double> term = arma::dot(firstCoefArray, extendMotifFT(motifFT) * secondCoefArray);
+
+    /* Instead of extending the motifFT matrix, reduce the coefs vectors */
+    arma::cx_vec reducedFirstCoefArray = arma::zeros<arma::cx_vec>(natoms);
+    arma::cx_vec reducedSecondCoefArray = arma::zeros<arma::cx_vec>(natoms);
+
+    int iterator = 0;
+    for(unsigned int atom_index = 0; atom_index < this->motif.n_rows; atom_index++){
+        int norbitals = orbitals(motif.row(atom_index)(3));
+
+        reducedFirstCoefArray(atom_index) = arma::sum(firstCoefArray.subvec(iterator, iterator + norbitals - 1));
+        reducedSecondCoefArray(atom_index) = arma::sum(secondCoefArray.subvec(iterator, iterator + norbitals - 1));
+
+        iterator += norbitals;
+    }
+
+    std::complex<double> term = arma::dot(reducedFirstCoefArray, motifFT * reducedSecondCoefArray);
+
     return term;
 };
 
@@ -1351,19 +1368,12 @@ arma::rowvec Exciton::findElectronHolePair(const Exciton& targetExciton, double 
             eigval = eigval(targetExciton.bandList);
             vEnergy = eigval(0);
 
-            eigvec = fixGlobalPhase(eigvec);
-            eigvec = eigvec.cols(targetExciton.bandList);
-            auxCoefsK = eigvec.col(0);
-
             if(arma::norm(Q) != 0){
                 arma::rowvec kQ = k + Q;
                 targetExciton.solveBands(kQ, eigval, eigvec);
 
                 eigval = eigval(targetExciton.bandList);
-                eigvec = fixGlobalPhase(eigvec);
-                eigvec = eigvec.cols(targetExciton.bandList);
             }
-            auxCoefsKQ = eigvec.col(1);
             cEnergy = eigval(1);
 
             gap = cEnergy - vEnergy;
@@ -1371,18 +1381,12 @@ arma::rowvec Exciton::findElectronHolePair(const Exciton& targetExciton, double 
                 currentIndex = i;
                 currentEnergy = gap;
 
-                coefsK = auxCoefsK;
-                coefsKQ = auxCoefsKQ;
-
                 kmin = min_k * (1 - (currentIndex - 1)/n) + max_k * (currentIndex - 1)/n;
                 kmax = min_k * (1 - (currentIndex + 1)/n) + max_k * (currentIndex + 1)/n;
             }
             if (increasing && (gap > energy) && (prevGap <= energy)){
                 currentIndex = i;
                 currentEnergy = gap;
-
-                coefsK = auxCoefsK;
-                coefsKQ = auxCoefsKQ;
 
                 kmin = min_k * (1 - (currentIndex - 1)/n) + max_k * (currentIndex - 1)/n;
                 kmax = min_k * (1 - (currentIndex + 1)/n) + max_k * (currentIndex + 1)/n;
@@ -1403,25 +1407,6 @@ arma::rowvec Exciton::findElectronHolePair(const Exciton& targetExciton, double 
     }
 
     arma::cout << "k: " << k << arma::endl;
-
-    bool computeOccupations = false;
-    if (computeOccupations){
-        //////// Specific for Bi ribbon; must be deleted afterwards.
-        int N = targetExciton.basisdim;
-        double l_e_edge_occ = arma::norm(coefsKQ.subvec(0, 15));
-        double r_e_edge_occ = arma::norm(coefsKQ.subvec(N - 16, N - 1));
-        double l_h_edge_occ = arma::norm(coefsK.subvec(0, 15));
-        double r_h_edge_occ = arma::norm(coefsK.subvec(N - 16, N - 1));
-
-        std::cout << "left e occ.: " << l_e_edge_occ << "\nright e occ: " << r_e_edge_occ << std::endl;
-        std::cout << "Total e occ.: " << std::sqrt(l_e_edge_occ*l_e_edge_occ + r_e_edge_occ*r_e_edge_occ) << arma::endl;
-        std::cout << "--------------------------------------" << std::endl;
-        std::cout << "left h occ.: " << l_h_edge_occ << "\nright h occ: " << r_h_edge_occ << std::endl;
-        std::cout << "Total h occ.: " << std::sqrt(l_h_edge_occ*l_h_edge_occ + r_h_edge_occ*r_h_edge_occ) << arma::endl;
-        std::cout << "--------------------------------------" << std::endl;
-        std::cout << "Total e-h pair edge occu.: " << std::sqrt(l_e_edge_occ*l_e_edge_occ + r_e_edge_occ*r_e_edge_occ) + 
-                    std::sqrt(l_h_edge_occ*l_h_edge_occ + r_h_edge_occ*r_h_edge_occ) << std::endl;
-    }
 
     return k;
 };
@@ -1460,6 +1445,25 @@ double Exciton::edgeFermiGoldenRule(const Exciton& targetExciton, const arma::cx
         eigvec = eigvec.cols(targetExciton.bandList);
     }
     coefsKQ = eigvec.col(1);
+
+    bool computeOccupations = true;
+    if (computeOccupations){
+        //////// Specific for Bi ribbon; must be deleted afterwards.
+        int N = targetExciton.basisdim;
+        double l_e_edge_occ = arma::norm(coefsKQ.subvec(0, 15));
+        double r_e_edge_occ = arma::norm(coefsKQ.subvec(N - 16, N - 1));
+        double l_h_edge_occ = arma::norm(coefsK.subvec(0, 15));
+        double r_h_edge_occ = arma::norm(coefsK.subvec(N - 16, N - 1));
+
+        std::cout << "left e occ.: " << l_e_edge_occ << "\nright e occ: " << r_e_edge_occ << std::endl;
+        std::cout << "Total e occ.: " << std::sqrt(l_e_edge_occ*l_e_edge_occ + r_e_edge_occ*r_e_edge_occ) << arma::endl;
+        std::cout << "--------------------------------------" << std::endl;
+        std::cout << "left h occ.: " << l_h_edge_occ << "\nright h occ: " << r_h_edge_occ << std::endl;
+        std::cout << "Total h occ.: " << std::sqrt(l_h_edge_occ*l_h_edge_occ + r_h_edge_occ*r_h_edge_occ) << arma::endl;
+        std::cout << "--------------------------------------" << std::endl;
+        std::cout << "Total e-h pair edge occu.: " << std::sqrt(l_e_edge_occ*l_e_edge_occ + r_e_edge_occ*r_e_edge_occ) + 
+                    std::sqrt(l_h_edge_occ*l_h_edge_occ + r_h_edge_occ*r_h_edge_occ) << std::endl;
+    }
     
     // Now compute motif FT using k of edge pair
     
@@ -1468,6 +1472,7 @@ double Exciton::edgeFermiGoldenRule(const Exciton& targetExciton, const arma::cx
 
     arma::cx_cube ftMotifStack = arma::cx_cube(natoms, natoms, meshBZ_.n_rows);
     
+    #pragma omp parallel for collapse(2)
     for(int i = 0; i < nk; i++){
         for(int fAtomIndex = 0; fAtomIndex < natoms; fAtomIndex++){
             for(int sAtomIndex = fAtomIndex; sAtomIndex < natoms; sAtomIndex++){
@@ -1481,7 +1486,7 @@ double Exciton::edgeFermiGoldenRule(const Exciton& targetExciton, const arma::cx
     arma::cx_vec W = arma::zeros<arma::cx_vec>(initialBasis.n_rows);
 
     // -------- Main loop (W initialization) --------
-    #pragma omp parallel for
+    // #pragma omp parallel for
     for (int i = 0; i < initialBasis.n_rows; i++){
 
         arma::cx_vec coefsK2, coefsK2Q;
@@ -1522,6 +1527,8 @@ double Exciton::edgeFermiGoldenRule(const Exciton& targetExciton, const arma::cx
     double hbar = 6.582119624E-16; // Units are eV*s
 
     transitionRate = (ncell*a)*2*PI*std::norm(arma::dot(W, initialState))*rho/hbar;
+
+    arma::cout << "Rate: " << transitionRate << arma::endl;
 
     return transitionRate;
 }

--- a/src/Exciton.cpp
+++ b/src/Exciton.cpp
@@ -1528,7 +1528,6 @@ double Exciton::edgeFermiGoldenRule(const Exciton& targetExciton, const arma::cx
 
     transitionRate = (ncell*a)*2*PI*std::norm(arma::dot(W, initialState))*rho/hbar;
 
-    arma::cout << "Rate: " << transitionRate << arma::endl;
 
     return transitionRate;
 }

--- a/src/Result.cpp
+++ b/src/Result.cpp
@@ -87,12 +87,11 @@ int Result::findExcitonPeak(int stateindex){
 /** 
  * Routine to compute the expected Sz spin value of the electron
  * and hole that form a given exciton.
- * @param stateindex Index of the exciton.
+ * @param coefs Coefficients of the exciton state. Note that the coefficients must be given
+ * in the exact ordering used in the exciton basis. Otherwise, wrong results will be obtained.
  * @return Vector with the total spin of the exciton, the spin of the hole and that of the electron
  */
-arma::cx_vec Result::spinX(int stateindex){
-
-    arma::cx_vec coefs = eigvec.col(stateindex);
+arma::cx_vec Result::spinX(const arma::cx_vec& coefs){
     
     // Initialize Sz for both electron and hole to zero
     arma::cx_double electronSpin = 0;
@@ -128,38 +127,38 @@ arma::cx_vec Result::spinX(int stateindex){
     arma::mat bandPairs = arma::zeros(npairs, 2);
     int i = 0;
     for(double v : exciton.valenceBands){
-        for(double c : exciton.conductionBands){
-            bandPairs.row(i) = arma::rowvec{v, c};
-            i++;
-        }
+    for(double c : exciton.conductionBands){
+    bandPairs.row(i) = arma::rowvec{v, c};
+    i++;
+    }
     }
 
     for(unsigned int k = 0; k < exciton.kpoints.n_rows; k++){
-        arma::cx_mat spinHoleReduced = arma::zeros<arma::cx_mat>(nvbands, nvbands);
-        arma::cx_mat spinElectronReduced = arma::zeros<arma::cx_mat>(ncbands, ncbands);
-        for(int i = 0; i < nvbands; i++){
-            int vIndex = exciton.bandToIndex[exciton.valenceBands(i)];
-            for(int j = 0; j < nvbands; j++){
-                int vIndex2 = exciton.bandToIndex[exciton.valenceBands(j)];
-                eigvec = exciton.eigvecKStack.slice(k).col(vIndex);
-                spinEigvec = eigvec % spinVector;
-                eigvec = exciton.eigvecKStack.slice(k).col(vIndex2);
-                spinHoleReduced(i,j) = arma::cdot(eigvec, spinEigvec);
-            }
+    arma::cx_mat spinHoleReduced = arma::zeros<arma::cx_mat>(nvbands, nvbands);
+    arma::cx_mat spinElectronReduced = arma::zeros<arma::cx_mat>(ncbands, ncbands);
+    for(int i = 0; i < nvbands; i++){
+    int vIndex = exciton.bandToIndex[exciton.valenceBands(i)];
+    for(int j = 0; j < nvbands; j++){
+    int vIndex2 = exciton.bandToIndex[exciton.valenceBands(j)];
+    eigvec = exciton.eigvecKStack.slice(k).col(vIndex);
+    spinEigvec = eigvec % spinVector;
+    eigvec = exciton.eigvecKStack.slice(k).col(vIndex2);
+    spinHoleReduced(i,j) = arma::cdot(eigvec, spinEigvec);
+    }
         }
         for(int i = 0; i < ncbands; i++){
-            int cIndex = exciton.bandToIndex[exciton.conductionBands(i)];
-            for(int j = 0; j < ncbands; j++){
-                int cIndex2 = exciton.bandToIndex[exciton.conductionBands(j)];
-                eigvec = exciton.eigvecKQStack.slice(k).col(cIndex2);
-                spinEigvec = eigvec % spinVector;
-                eigvec = exciton.eigvecKQStack.slice(k).col(cIndex);
-                spinElectronReduced(i,j) = arma::cdot(eigvec, spinEigvec);
-            }
+    int cIndex = exciton.bandToIndex[exciton.conductionBands(i)];
+    for(int j = 0; j < ncbands; j++){
+    int cIndex2 = exciton.bandToIndex[exciton.conductionBands(j)];
+    eigvec = exciton.eigvecKQStack.slice(k).col(cIndex2);
+    spinEigvec = eigvec % spinVector;
+    eigvec = exciton.eigvecKQStack.slice(k).col(cIndex);
+    spinElectronReduced(i,j) = arma::cdot(eigvec, spinEigvec);
+    }
         }
             
-        spinHole.submat(k*npairs, k*npairs, (k+1)*npairs - 1, (k+1)*npairs - 1) = arma::kron(cMatrix, spinHoleReduced);
-        spinElectron.submat(k*npairs, k*npairs, (k+1)*npairs - 1, (k+1)*npairs - 1) = arma::kron(spinElectronReduced, vMatrix);
+    spinHole.submat(k*npairs, k*npairs, (k+1)*npairs - 1, (k+1)*npairs - 1) = arma::kron(cMatrix, spinHoleReduced);
+    spinElectron.submat(k*npairs, k*npairs, (k+1)*npairs - 1, (k+1)*npairs - 1) = arma::kron(spinElectronReduced, vMatrix);
     }
 
     // Perform tensor products with the remaining quantum numbers
@@ -171,69 +170,17 @@ arma::cx_vec Result::spinX(int stateindex){
     return results;
 }
 
-/**
- * Method to compute the oscillator strength of the exciton.
- * @details Computes the oscillator strength of the exciton, which is a measure of the brightness
- * of the exciton, and it is used to obtain the optical conducitivity.
- * @return Matrix with all the oscillator strenghts in all three directions for all excitons.
+/** 
+ * Routine to compute the expected Sz spin value of the electron
+ * and hole that form a given exciton.
+ * @param stateIndex Index of the exciton state.
+ * @return Vector with the total spin of the exciton, the spin of the hole and that of the electron
  */
-arma::cx_mat Result::excitonOscillatorStrength(){
+arma::cx_vec Result::spinX(int stateIndex){
+    arma::cx_vec coefs = eigvec.col(stateIndex);
+    arma::cx_vec spin = spinX(coefs);
 
-    int nR = exciton.unitCellList.n_rows;
-    int norb = exciton.basisdim;
-    int norb_ex = exciton.excitonbasisdim;
-    int filling = exciton.filling;
-    int nv = exciton.valenceBands.n_elem;
-    int nc = exciton.conductionBands.n_elem;
-
-    arma::mat Rvec = exciton.unitCellList;
-    // Extend bravais lattice to 3x3 matrix
-    arma::mat R = arma::zeros(3, 3);
-    for (int i = 0; i < exciton.bravaisLattice.n_rows; i++){
-        R.row(i) = exciton.bravaisLattice.row(i);
-    }
-
-    // arma::mat B = exciton.motif.cols(0, 2);
-    arma::mat extendedMotif = arma::zeros(exciton.basisdim, 3);
-    int it = 0;
-    for(int i = 0; i < exciton.natoms; i++){
-        arma::rowvec atom = exciton.motif.row(i).subvec(0, 2);
-        int species = exciton.motif.row(i)(3);
-        for(int j = 0; j < exciton.orbitals(species); j++){
-            extendedMotif.row(it) = atom; 
-            it++;
-        }
-    }
-    arma::cx_cube hhop = exciton.hamiltonianMatrices;
-    arma::cube shop(arma::size(hhop));
-    if (exciton.overlapMatrices.empty()){
-        for (int i = 0; i < hhop.n_slices; i++){
-            shop.slice(i) = arma::eye(size(hhop.slice(i)));
-        }
-    }
-    else{
-        shop = arma::real(exciton.overlapMatrices);
-    }
-    int nk = exciton.nk;
-    arma::vec rkx = exciton.kpoints.col(0);
-    arma::vec rky = exciton.kpoints.col(1);
-    arma::vec rkz = exciton.kpoints.col(2);
-
-    arma::mat eigval_sp = exciton.eigvalKStack;
-    arma::cx_cube eigvec_sp = exciton.eigvecKStack;
-
-    arma::cx_cube vme_ex = arma::zeros<arma::cx_cube>(3, norb_ex, 2);
-
-    std::complex<double>* vme = new std::complex<double>[3*nk*(nv + nc)*(nv + nc)];
-    bool convert_to_au = true;
-
-
-    exciton_oscillator_strength_(&nR, &norb, &norb_ex, &nv, &nc, &filling, 
-             Rvec.memptr(), R.memptr(), extendedMotif.memptr(), hhop.memptr(), shop.memptr(), &nk, rkx.memptr(),
-             rky.memptr(), rkz.memptr(), m_eigvec.memptr(), m_eigval.memptr(), eigval_sp.memptr(), eigvec_sp.memptr(),
-             vme, vme_ex.memptr(), &convert_to_au);
-
-    return vme_ex.slice(0);
+    return spin;
 }
 
 /**


### PR DESCRIPTION
Now the calculation of the interaction matrix elements is faster as the calculation has been reduced to a bilinear form of smaller dimension. Also added routine for calculation of single particle velocity matrix elements.