### PR TITLE
Anisotropic keldysh + Out-of-plane conductivity

### DIFF
--- a/include/xatu/ExcitonConfiguration.hpp
+++ b/include/xatu/ExcitonConfiguration.hpp
@@ -32,6 +32,10 @@ class ExcitonConfiguration : public ConfigurationBase{
         arma::vec eps = {};
         // Screening length
         double r0;
+        // Screening length
+        double ry;
+        // Screening length
+        double rz;
         // Thickness of layer
         double d;
         // Calculation mode (either 'realspace' or 'reciprocalspace')

--- a/include/xatu/ExcitonTB.hpp
+++ b/include/xatu/ExcitonTB.hpp
@@ -104,7 +104,6 @@ class ExcitonTB : public Exciton<SystemTB> {
     private:
         // Potentials
         double keldysh(arma::rowvec);
-        double Q2DRK(double);
         void STVH0(double, double*);
         double coulomb(arma::rowvec);
         potptr selectPotential(std::string);

--- a/include/xatu/ExcitonTB.hpp
+++ b/include/xatu/ExcitonTB.hpp
@@ -18,7 +18,7 @@ namespace xatu {
 // Definitions
 
 // Define pointer to potential function type (f: R -> R) within those in ExcitonTB
-typedef double (ExcitonTB::*potptr)(double);
+typedef double (ExcitonTB::*potptr)(arma::rowvec);
 class ResultTB;
 
 class ExcitonTB : public Exciton<SystemTB> {
@@ -28,7 +28,7 @@ class ExcitonTB : public Exciton<SystemTB> {
     private:
         
         // Keldysh potential constants
-        double eps_m_, eps_s_, r0_;
+        double eps_m_, eps_s_, r0_, ry_, rz_;
         double regularization_;
 
         // Flags
@@ -52,6 +52,10 @@ class ExcitonTB : public Exciton<SystemTB> {
         const double& eps_s = eps_s_;
         // Returns effective screening length r0
         const double& r0 = r0_;
+        // Returns effective screening length ry
+        const double& ry = ry_;
+        // Returns effective screening length rz
+        const double& rz = rz_;
         // Returns regularization distance
         const double& regularization = regularization_;
         // Returns gauge for Bloch states
@@ -70,28 +74,28 @@ class ExcitonTB : public Exciton<SystemTB> {
     public:
         // Specify number of bands participating (int)
         ExcitonTB(const SystemConfiguration&, int ncell = 20, int nbands = 1, int nrmbands = 0, 
-                 const arma::rowvec& parameters = {1, 5, 1}, const arma::rowvec& Q = {0., 0., 0.});
+                 const arma::rowvec& parameters = {1, 5, 1, 1, 1}, const arma::rowvec& Q = {0., 0., 0.});
 
         // Specify which bands participate (vector with band numbers)
         ExcitonTB(const SystemConfiguration&, int ncell = 20, const arma::ivec& bands = {0, 1}, 
-                 const arma::rowvec& parameters = {1, 5, 1}, const arma::rowvec& Q = {0., 0., 0.});
+                 const arma::rowvec& parameters = {1, 5, 1, 1, 1}, const arma::rowvec& Q = {0., 0., 0.});
         
         // Use two files: the mandatory one for system config., and one for exciton config.
         ExcitonTB(const SystemConfiguration&, const ExcitonConfiguration&);
 
         // Initialize exciton passing directly a System object instead of a file using removed bands
         ExcitonTB(std::shared_ptr<SystemTB>, int ncell = 20, int nbands = 1, int nrmbands = 0, 
-                 const arma::rowvec& parameters = {1, 5, 1}, const arma::rowvec& Q = {0., 0., 0.});
+                 const arma::rowvec& parameters = {1, 5, 1, 1, 1}, const arma::rowvec& Q = {0., 0., 0.});
 
         // Initialize exciton passing directly a System object instead of a file using bands vector
         ExcitonTB(std::shared_ptr<SystemTB>, int ncell = 20, const arma::ivec& bands = {0, 1}, 
-                 const arma::rowvec& parameters = {1, 5, 1}, const arma::rowvec& Q = {0., 0., 0.});
+                 const arma::rowvec& parameters = {1, 5, 1, 1, 1}, const arma::rowvec& Q = {0., 0., 0.});
 
         ~ExcitonTB();
 
         // Setters
         void setParameters(const arma::rowvec&);
-        void setParameters(double, double, double);
+        void setParameters(double, double, double, double, double);
         void setGauge(std::string);
         void setMode(std::string);
         void setReciprocalVectors(int);
@@ -99,9 +103,10 @@ class ExcitonTB : public Exciton<SystemTB> {
 
     private:
         // Potentials
-        double keldysh(double);
+        double keldysh(arma::rowvec);
+        double Q2DRK(double);
         void STVH0(double, double*);
-        double coulomb(double);
+        double coulomb(arma::rowvec);
         potptr selectPotential(std::string);
 
         // Fourier transforms

--- a/include/xatu/Result.tpp
+++ b/include/xatu/Result.tpp
@@ -407,12 +407,17 @@ void Result<T>::writeEigenvalues(FILE* textfile, int n){
         throw std::invalid_argument("Optional argument n must be a positive integer equal or below basisdim");
     }
 
-    fprintf(textfile, "%d\t", exciton->excitonbasisdim);
-    int maxEigval = (n == 0) ? exciton->excitonbasisdim : n;  
-    for(unsigned int i = 0; i < maxEigval; i++){
-        fprintf(textfile, "%11.7lf\t", eigval(i));
+    // first line: number of cells
+    fprintf(textfile, "%d\n", exciton->excitonbasisdim);
+
+    // second line: how many eigenvalues will follow
+    int maxEigval = (n == 0) ? exciton->excitonbasisdim : n;
+    fprintf(textfile, "%d\n", maxEigval);
+
+    // then one eigenvalue per line
+    for(int i = 0; i < maxEigval; ++i){
+        fprintf(textfile, " %11.7lf\n", eigval(i));
     }
-    fprintf(textfile, "\n");
 }
 
 /**

--- a/include/xatu/ResultTB.hpp
+++ b/include/xatu/ResultTB.hpp
@@ -18,7 +18,7 @@ extern "C" {
                   std::complex<double>* hhop, double* shop, int* nk, double* rkx, 
                   double* rky, double* rkz, std::complex<double>* fk_ex, double* e_ex, 
                   double* eigval_stack, std::complex<double>* eigvec_stack, std::complex<double>* vme,
-                  std::complex<double>* vme_ex, bool* convert_to_au);
+                  std::complex<double>* vme_ex, int* convert_to_au);
 }
 
 namespace xatu {

--- a/plot/conductivity.py
+++ b/plot/conductivity.py
@@ -1,135 +1,197 @@
-import matplotlib.pyplot as plt
-import numpy as np
+#!/usr/bin/env python3
 import sys
+import numpy as np
+import matplotlib.pyplot as plt
 
-# Egap = sys.argv[1]
+def configure_matplotlib(fontsize=15, markersize=110, use_latex=True):
+    """Set global matplotlib rcParams."""
+    if use_latex:
+        plt.rcParams.update({
+            "text.usetex": True,
+            "font.family": "serif"
+        })
+    plt.rcParams["axes.labelsize"]   = fontsize
+    plt.rcParams["axes.titlesize"]   = fontsize
+    plt.rcParams["xtick.labelsize"]  = fontsize
+    plt.rcParams["ytick.labelsize"]  = fontsize
+    plt.rcParams["legend.fontsize"]  = fontsize
+    plt.rcParams["font.size"]        = fontsize
 
-# -----------------------------------------------------------
-# Configure plot
-# -----------------------------------------------------------
 
-exciton_file = sys.argv[1]
-sp_file      = sys.argv[2]
-plotType     = int(sys.argv[3])
-# states_file  = "in2se3.eigval"
-fontsize     = 15
-markersize   = 110  # Adjust size of points in plot
-latex        = True # Set to True if latex is installed
-if latex:
-    plt.rcParams.update({
-        "text.usetex": True,
-        "font.family": "serif"
-    })
-plt.rcParams["axes.labelsize"] = fontsize
-plt.rcParams["axes.titlesize"] = fontsize
-plt.rcParams["xtick.labelsize"] = fontsize
-plt.rcParams["ytick.labelsize"] = fontsize
-plt.rcParams["legend.fontsize"] = fontsize
-plt.rcParams["font.size"] = fontsize
+def read_exciton_file(path):
+    """
+    Read exciton file: energy and BSE conductivities only.
+    Returns:
+      energy, sigma_xx, sigma_yy, sigma_zz
+    """
+    energy = []
+    sigma_xx = []
+    sigma_yy = []
+    sigma_zz = []
 
-# -----------------------------------------------------------
-# Extract conductivies from files
-# -----------------------------------------------------------
+    with open(path, 'r') as f:
+        for raw in f:
+            parts = raw.split()
+            if not parts:
+                break
+            vals = [float(v) for v in parts]
+            energy.append(vals[0])
+            sigma_xx.append(vals[1])
+            sigma_yy.append(vals[5])
+            sigma_zz.append(vals[9])
 
-file = open(exciton_file, "r")
-energy, sigma_sp_xx, sigma_sp_yy, sigma_sp_zz = [], [], [], []
-sigma_xx, sigma_yy, sigma_zz = [], [], []
-E, Vx, Vy, Vz = [], [], [], []
+    return np.array(energy), np.array(sigma_xx), np.array(sigma_yy), np.array(sigma_zz)
 
-flag = 1
-for line in file.readlines():
-    line = [float(value) for value in line.split()]
-    if not line: # Skip reading exciton velocity matrix elements
-        flag = 2
-        continue
-    if flag == 1:
-        energy.append(line[0])
-        sigma_xx.append(line[1])
-        sigma_yy.append(line[5])
-        sigma_zz.append(line[9])
-    else:
-        E.append(line[0])
-        Vx.append(np.abs(line[1]+line[2]*1j)**2)
-        Vy.append(np.abs(line[3]+line[4]*1j)**2)
-        Vz.append(np.abs(line[5]+line[6]*1j)**2)
 
-E  = np.array(E)
-Vx = np.array(Vx)
-Vy = np.array(Vy)
-Vz = np.array(Vz)
+def read_sp_file(path):
+    """
+    Read single-particle conductivity file.
+    Returns:
+      sigma_sp_xx, sigma_sp_yy, sigma_sp_zz
+    """
+    sigma_sp_xx = []
+    sigma_sp_yy = []
+    sigma_sp_zz = []
+    with open(path, 'r') as f:
+        for raw in f:
+            vals = [float(v) for v in raw.split()]
+            sigma_sp_xx.append(vals[1])
+            sigma_sp_yy.append(vals[5])
+            sigma_sp_zz.append(vals[9])
+    return np.array(sigma_sp_xx), np.array(sigma_sp_yy), np.array(sigma_sp_zz)
 
-file = open(sp_file, "r")
-for line in file.readlines():
-    line = [float(value) for value in line.split()]
-    sigma_sp_xx.append(line[1])
-    sigma_sp_yy.append(line[5])
-    sigma_sp_zz.append(line[9])
 
-# -----------------------------------------------------------
-# Plot states
-# -----------------------------------------------------------
+def read_oscillator_file(path):
+    """
+    Read oscillator strengths from third file.
+    Returns:
+      E_exc, Vx, Vy, Vz
+    """
+    E_exc = []
+    Vx = []
+    Vy = []
+    Vz = []
+    with open(path, 'r') as f:
+        for raw in f:
+            parts = raw.split()
+            if not parts:
+                continue
+            vals = [float(v) for v in parts]
+            E_exc.append(vals[0])
+            Vx.append(abs(vals[1] + 1j*vals[2])**2)
+            Vy.append(abs(vals[3] + 1j*vals[4])**2)
+            Vz.append(abs(vals[5] + 1j*vals[6])**2)
+    return np.array(E_exc), np.array(Vx), np.array(Vy), np.array(Vz)
 
-# plot conductivity
-if plotType == 1:
-    fig, ax = plt.subplots(figsize=(6.4,4.8))
-    ax.plot(energy, sigma_xx, "r-", label="BSE_xx",alpha=0.6)
-    ax.plot(energy, sigma_yy, "orange", label="BSE_yy",alpha=0.6)
-    ax.plot(energy, sigma_zz, "g-", label="BSE_zz",alpha=0.6)
+
+def print_header(plot_type, output_file):
+    """Prints a standardized header with current plot info."""
+    print("===================================")
+    print("       PLOTTING CONDUCTIVITY       ")
+    print("===================================")
+    print(f"Selected plot type: {plot_type}")
+    print(f"Output file: {output_file}")
+    print()
+
+
+def print_usage():
+    print("Usage:")
+    print("  script.py <exciton_file> <sp_file> [oscillator_file]")
+    print()
+    print("Running with two files does plot type 1.")
+    print("Add a third file to get plot type 2.")
+
+
+def plot_type1(energy, sigma_xx, sigma_yy, sigma_zz,
+               sigma_sp_xx, sigma_sp_yy, sigma_sp_zz,
+               output="conductivity.png"):
+    fig, ax = plt.subplots(figsize=(6.4, 4.8))
+    ax.plot(energy, sigma_xx,    "r-",  label="BSE_xx", alpha=0.6)
+    ax.plot(energy, sigma_yy,    "orange", label="BSE_yy", alpha=0.6)
+    ax.plot(energy, sigma_zz,    "g-",  label="BSE_zz", alpha=0.6)
     ax.plot(energy, sigma_sp_xx, "b--", label="IPA_xx")
     ax.plot(energy, sigma_sp_yy, "c--", label="IPA_yy")
-    ax.plot(energy, sigma_sp_zz, c="navy", ls='--', label="IPA_zz")
+    ax.plot(energy, sigma_sp_zz, ls="--", c="navy", label="IPA_zz")
 
     ax.set_xlabel("E (eV)", fontsize=18)
     ax.set_ylabel(r"$\sigma$ ($e^2/\hbar$)", fontsize=18)
-    ax.legend(fontsize=fontsize/1.5)
-    ax.set_xlim(energy[0],energy[-1])
+    ax.legend()
+    ax.set_xlim(energy[0], energy[-1])
     plt.tight_layout()
-    plt.savefig("conductivity.png", dpi = 400)
+    plt.savefig(output, dpi=600)
 
-# plot conductivity + oscillator strengths
-elif plotType == 2:
-    fig, ax = plt.subplots(2,1, figsize=(6.4,4.8))
-    ax[0].plot(energy, sigma_xx, "r-", label="BSE_xx")
-    ax[0].plot(energy, sigma_yy, "orange", label="BSE_yy")
-    ax[0].plot(energy, sigma_zz, "g-", label="BSE_zz")
-    ax[0].plot(energy, sigma_sp_xx, "b--", label="IPA_xx")
-    ax[0].plot(energy, sigma_sp_yy, "c--", label="IPA_yy")
-    ax[0].plot(energy, sigma_sp_zz, "navy", ls='--', label="IPA_zz")
 
-    # ax[0].set_xlabel("E (eV)", fontsize=18)
-    ax[0].set_ylabel(r"$\sigma$ ($e^2/\hbar$)", fontsize=18)
+def plot_type2(energy, sigma_xx, sigma_yy, sigma_zz,
+               sigma_sp_xx, sigma_sp_yy, sigma_sp_zz,
+               E_exc, Vx, Vy, Vz,
+               output="conductivity_oscillators.png"):
+    fig, axes = plt.subplots(2, 1, figsize=(6.4, 4.8))
+    ax1 = axes[0]
+    ax1.plot(energy, sigma_xx,    "r-",     label="BSE_xx")
+    ax1.plot(energy, sigma_yy,    "orange", label="BSE_yy")
+    ax1.plot(energy, sigma_zz,    "g-",     label="BSE_zz")
+    ax1.plot(energy, sigma_sp_xx, "b--",    label="IPA_xx")
+    ax1.plot(energy, sigma_sp_yy, "c--",    label="IPA_yy")
+    ax1.plot(energy, sigma_sp_zz, ls="--",  c="navy", label="IPA_zz")
+    ax1.set_ylabel(r"$\sigma$ ($e^2/\hbar$)", fontsize=18)
 
-    # Create masks for your conditions
+    ax2 = axes[1]
+
+    # mask weak oscilaltors (plotting everything is costly and messy)
     mask_vx = Vx > 0.1
     mask_vy = Vy > 0.1
     mask_vz = Vz > 0.5
 
-    # Plot all Vx bars with a single label
-    if np.any(mask_vx):
-        ax[1].bar(E[mask_vx], E[mask_vx]*Vx[mask_vx], 
-                 width=0.03, color="r", alpha=0.3, label='xx')
+    if mask_vx.any():
+        ax2.bar(E_exc[mask_vx], E_exc[mask_vx]*Vx[mask_vx], width=0.03, alpha=0.3, label="xx")
+    if mask_vy.any():
+        ax2.bar(E_exc[mask_vy], E_exc[mask_vy]*Vy[mask_vy], width=0.03, alpha=0.3, label="yy")
+    if mask_vz.any():
+        ax2.bar(E_exc[mask_vz], E_exc[mask_vz]*Vz[mask_vz], width=0.03, alpha=0.3, label="zz")
 
-    # Plot all Vy bars with a single label
-    if np.any(mask_vy):
-        ax[1].bar(E[mask_vy], E[mask_vy]*Vy[mask_vy], 
-                 width=0.03, color="orange", alpha=0.3, label='yy')
+    ax2.set_ylabel(r"$|V^\alpha|^2$", fontsize=18)
+    ax2.set_xlabel("E (eV)", fontsize=18)
 
-    # Plot all Vy bars with a single label
-    if np.any(mask_vz):
-        ax[1].bar(E[mask_vz], E[mask_vz]*Vz[mask_vz], 
-                 width=0.03, color="green", alpha=0.3, label='zz')
+    for ax in axes:
+        ax.set_xlim(energy[0], energy[-1])
+        ax.tick_params(labelsize=12)
 
-    ax[1].set_ylabel(f'$|V^\\alpha|^2$', fontsize=18) # $A_{vc}(\mathbf{k})v_{vc}^{\alpha}(\mathbf{k})$
-    ax[1].set_xlabel("E (eV)", fontsize=18)
-
-    for axs in ax:
-        axs.set_xlim(energy[0],energy[-1])
-        axs.tick_params(labelsize=12)
-
-    plt.subplots_adjust(wspace=0, hspace=0.1)
-
-    ax[0].legend(fontsize=fontsize/1.5)
-    ax[1].legend(fontsize=fontsize/1.5)
+    ax1.legend()
+    ax2.legend()
+    plt.subplots_adjust(hspace=0.1)
     plt.tight_layout()
-    plt.savefig("conductivity_oscillators.png", dpi = 400)
-plt.show()
+    plt.savefig(output, dpi=600)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print_usage()
+        sys.exit(1)
+
+    exciton_path = sys.argv[1]
+    sp_path      = sys.argv[2]
+    has_osc      = len(sys.argv) == 4
+    plot_type    = 2 if has_osc else 1
+    output_file  = "conductivity_oscillators.png" if has_osc else "conductivity.png"
+
+    print_header(plot_type, output_file)
+    configure_matplotlib()
+
+    energy, sigma_xx, sigma_yy, sigma_zz = read_exciton_file(exciton_path)
+    sigma_sp_xx, sigma_sp_yy, sigma_sp_zz = read_sp_file(sp_path)
+
+    if plot_type == 1:
+        plot_type1(energy, sigma_xx, sigma_yy, sigma_zz,
+                   sigma_sp_xx, sigma_sp_yy, sigma_sp_zz,
+                   output_file)
+    else:
+        E_exc, Vx, Vy, Vz = read_oscillator_file(sys.argv[3])
+        plot_type2(energy, sigma_xx, sigma_yy, sigma_zz,
+                   sigma_sp_xx, sigma_sp_yy, sigma_sp_zz,
+                   E_exc, Vx, Vy, Vz,
+                   output_file)
+
+    # plt.show()
+
+if __name__ == "__main__":
+    main()

--- a/plot/conductivity.py
+++ b/plot/conductivity.py
@@ -1,12 +1,17 @@
 import matplotlib.pyplot as plt
 import numpy as np
+import sys
+
+# Egap = sys.argv[1]
 
 # -----------------------------------------------------------
 # Configure plot
 # -----------------------------------------------------------
 
-exciton_file = "hBN_ex.dat"
-sp_file      = "hBN_sp.dat"
+exciton_file = sys.argv[1]
+sp_file      = sys.argv[2]
+plotType     = int(sys.argv[3])
+# states_file  = "in2se3.eigval"
 fontsize     = 15
 markersize   = 110  # Adjust size of points in plot
 latex        = True # Set to True if latex is installed
@@ -27,32 +32,92 @@ plt.rcParams["font.size"] = fontsize
 # -----------------------------------------------------------
 
 file = open(exciton_file, "r")
-energy, sigma_xx, sigma_yy, sigma_sp_xx, sigma_sp_yy = [], [], [], [], []
+energy, sigma_sp_xx, sigma_sp_yy, sigma_sp_zz = [], [], [], []
+sigma_xx, sigma_yy, sigma_zz = [], [], []
+Ex, Vx, Vy, Vz = [], [], [], []
+
+flag = 1
 for line in file.readlines():
     line = [float(value) for value in line.split()]
     if not line: # Skip reading exciton velocity matrix elements
-        break
-    energy.append(line[0])
-    sigma_xx.append(line[1])
-    sigma_yy.append(line[5])
-    
+        flag = 2
+        continue
+    if flag == 1:
+        energy.append(line[0])
+        sigma_xx.append(line[1])
+        sigma_yy.append(line[5])
+        sigma_zz.append(line[9])
+    else:
+        Ex.append(line[0])
+        Vx.append(np.abs(line[1]+line[2]*1j)**2)
+        Vy.append(np.abs(line[3]+line[4]*1j)**2)
+        Vz.append(np.abs(line[5]+line[6]*1j)**2)
+
+Ex = np.array(Ex)
+Vx = np.array(Vx)
+Vy = np.array(Vy)
+Vz = np.array(Vz)
+
 file = open(sp_file, "r")
 for line in file.readlines():
     line = [float(value) for value in line.split()]
     sigma_sp_xx.append(line[1])
     sigma_sp_yy.append(line[5])
+    sigma_sp_zz.append(line[9])
 
 # -----------------------------------------------------------
 # Plot states
 # -----------------------------------------------------------
 
-plt.plot(energy, sigma_xx, "g-", label="xx")
-plt.plot(energy, sigma_yy, "r-", label="yy")
-plt.plot(energy, sigma_sp_xx, "b--", label="sp_xx")
-plt.plot(energy, sigma_sp_yy, "c--", label="sp_yy")
-plt.xlabel("E (eV)")
-plt.ylabel(r"$\sigma$ ($e^2/\hbar$)")
+if plotType == 1:
+    fig, ax = plt.subplots(figsize=(6.4,4.8))
+    ax.plot(energy, sigma_xx, "g-", label="BSE_xx")
+    ax.plot(energy, sigma_yy, "r-", label="BSE_yy")
+    ax.plot(energy, sigma_sp_xx, "b--", label="IPA_xx")
+    ax.plot(energy, sigma_sp_yy, "c--", label="IPA_yy")
 
-plt.legend(fontsize=fontsize/1.5)
+    ax.set_xlabel("E (eV)", fontsize=18)
+    ax.set_ylabel(r"$\sigma$ ($e^2/\hbar$)", fontsize=18)
+    ax.legend(fontsize=fontsize/1.5)
+    ax.set_xlim(energy[0],energy[-1])
+    plt.tight_layout()
+    plt.savefig("conductivity.png", dpi = 400)
 
-plt.show()
+elif plotType == 2:
+    fig, ax = plt.subplots(2,1, figsize=(6.4,4.8))
+    ax[0].plot(energy, sigma_xx, "g-", label="BSE_xx")
+    ax[0].plot(energy, sigma_yy, "r-", label="BSE_yy")
+    ax[0].plot(energy, sigma_sp_xx, "b--", label="IPA_xx")
+    ax[0].plot(energy, sigma_sp_yy, "c--", label="IPA_yy")
+
+    # ax[0].set_xlabel("E (eV)", fontsize=18)
+    ax[0].set_ylabel(r"$\sigma$ ($e^2/\hbar$)", fontsize=18)
+
+    # Create masks for your conditions
+    mask_vx = Vx > 0.1
+    mask_vy = Vy > 0.1
+
+    # Plot all Vx bars with a single label
+    if np.any(mask_vx):
+        ax[1].bar(Ex[mask_vx], Ex[mask_vx]*Vx[mask_vx], 
+                 width=0.03, color="g", alpha=0.3, label='xx')
+
+    # Plot all Vy bars with a single label
+    if np.any(mask_vy):
+        ax[1].bar(Ex[mask_vy], Ex[mask_vy]*Vy[mask_vy], 
+                 width=0.03, color="r", alpha=0.3, label='yy')
+
+    ax[1].set_ylabel(f'$|V^\\alpha|^2$', fontsize=18) # $A_{vc}(\mathbf{k})v_{vc}^{\alpha}(\mathbf{k})$
+    ax[1].set_xlabel("E (eV)", fontsize=18)
+
+    for axs in ax:
+        axs.set_xlim(energy[0],energy[-1])
+        axs.tick_params(labelsize=12)
+
+    plt.subplots_adjust(wspace=0, hspace=0.1)
+
+    ax[0].legend(fontsize=fontsize/1.5)
+    ax[1].legend(fontsize=fontsize/1.5)
+    plt.tight_layout()
+    plt.savefig("conductivity_oscillators.png", dpi = 400)
+# plt.show()

--- a/plot/conductivity.py
+++ b/plot/conductivity.py
@@ -28,13 +28,13 @@ plt.rcParams["legend.fontsize"] = fontsize
 plt.rcParams["font.size"] = fontsize
 
 # -----------------------------------------------------------
-# First extract conductivies from files
+# Extract conductivies from files
 # -----------------------------------------------------------
 
 file = open(exciton_file, "r")
 energy, sigma_sp_xx, sigma_sp_yy, sigma_sp_zz = [], [], [], []
 sigma_xx, sigma_yy, sigma_zz = [], [], []
-Ex, Vx, Vy, Vz = [], [], [], []
+E, Vx, Vy, Vz = [], [], [], []
 
 flag = 1
 for line in file.readlines():
@@ -48,12 +48,12 @@ for line in file.readlines():
         sigma_yy.append(line[5])
         sigma_zz.append(line[9])
     else:
-        Ex.append(line[0])
+        E.append(line[0])
         Vx.append(np.abs(line[1]+line[2]*1j)**2)
         Vy.append(np.abs(line[3]+line[4]*1j)**2)
         Vz.append(np.abs(line[5]+line[6]*1j)**2)
 
-Ex = np.array(Ex)
+E  = np.array(E)
 Vx = np.array(Vx)
 Vy = np.array(Vy)
 Vz = np.array(Vz)
@@ -69,12 +69,15 @@ for line in file.readlines():
 # Plot states
 # -----------------------------------------------------------
 
+# plot conductivity
 if plotType == 1:
     fig, ax = plt.subplots(figsize=(6.4,4.8))
-    ax.plot(energy, sigma_xx, "g-", label="BSE_xx")
-    ax.plot(energy, sigma_yy, "r-", label="BSE_yy")
+    ax.plot(energy, sigma_xx, "r-", label="BSE_xx",alpha=0.6)
+    ax.plot(energy, sigma_yy, "orange", label="BSE_yy",alpha=0.6)
+    ax.plot(energy, sigma_zz, "g-", label="BSE_zz",alpha=0.6)
     ax.plot(energy, sigma_sp_xx, "b--", label="IPA_xx")
     ax.plot(energy, sigma_sp_yy, "c--", label="IPA_yy")
+    ax.plot(energy, sigma_sp_zz, c="navy", ls='--', label="IPA_zz")
 
     ax.set_xlabel("E (eV)", fontsize=18)
     ax.set_ylabel(r"$\sigma$ ($e^2/\hbar$)", fontsize=18)
@@ -83,12 +86,15 @@ if plotType == 1:
     plt.tight_layout()
     plt.savefig("conductivity.png", dpi = 400)
 
+# plot conductivity + oscillator strengths
 elif plotType == 2:
     fig, ax = plt.subplots(2,1, figsize=(6.4,4.8))
-    ax[0].plot(energy, sigma_xx, "g-", label="BSE_xx")
-    ax[0].plot(energy, sigma_yy, "r-", label="BSE_yy")
+    ax[0].plot(energy, sigma_xx, "r-", label="BSE_xx")
+    ax[0].plot(energy, sigma_yy, "orange", label="BSE_yy")
+    ax[0].plot(energy, sigma_zz, "g-", label="BSE_zz")
     ax[0].plot(energy, sigma_sp_xx, "b--", label="IPA_xx")
     ax[0].plot(energy, sigma_sp_yy, "c--", label="IPA_yy")
+    ax[0].plot(energy, sigma_sp_zz, "navy", ls='--', label="IPA_zz")
 
     # ax[0].set_xlabel("E (eV)", fontsize=18)
     ax[0].set_ylabel(r"$\sigma$ ($e^2/\hbar$)", fontsize=18)
@@ -96,16 +102,22 @@ elif plotType == 2:
     # Create masks for your conditions
     mask_vx = Vx > 0.1
     mask_vy = Vy > 0.1
+    mask_vz = Vz > 0.5
 
     # Plot all Vx bars with a single label
     if np.any(mask_vx):
-        ax[1].bar(Ex[mask_vx], Ex[mask_vx]*Vx[mask_vx], 
-                 width=0.03, color="g", alpha=0.3, label='xx')
+        ax[1].bar(E[mask_vx], E[mask_vx]*Vx[mask_vx], 
+                 width=0.03, color="r", alpha=0.3, label='xx')
 
     # Plot all Vy bars with a single label
     if np.any(mask_vy):
-        ax[1].bar(Ex[mask_vy], Ex[mask_vy]*Vy[mask_vy], 
-                 width=0.03, color="r", alpha=0.3, label='yy')
+        ax[1].bar(E[mask_vy], E[mask_vy]*Vy[mask_vy], 
+                 width=0.03, color="orange", alpha=0.3, label='yy')
+
+    # Plot all Vy bars with a single label
+    if np.any(mask_vz):
+        ax[1].bar(E[mask_vz], E[mask_vz]*Vz[mask_vz], 
+                 width=0.03, color="green", alpha=0.3, label='zz')
 
     ax[1].set_ylabel(f'$|V^\\alpha|^2$', fontsize=18) # $A_{vc}(\mathbf{k})v_{vc}^{\alpha}(\mathbf{k})$
     ax[1].set_xlabel("E (eV)", fontsize=18)
@@ -120,4 +132,4 @@ elif plotType == 2:
     ax[1].legend(fontsize=fontsize/1.5)
     plt.tight_layout()
     plt.savefig("conductivity_oscillators.png", dpi = 400)
-# plt.show()
+plt.show()

--- a/plot/kwf.py
+++ b/plot/kwf.py
@@ -99,5 +99,4 @@ ax[1,1].tick_params(labelbottom=True)
 
 plt.tight_layout()
 plt.savefig("kwf.png", dpi=600)
-plt.savefig("kwf.pdf", dpi=600)
 # plt.show()

--- a/plot/kwf.py
+++ b/plot/kwf.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-
+import sys
 # -----------------------------------------------------------
 # Configure plot
 # -----------------------------------------------------------
@@ -19,14 +19,13 @@ plt.rcParams["ytick.labelsize"] = fontsize
 plt.rcParams["legend.fontsize"] = fontsize
 plt.rcParams["font.size"] = fontsize
 
-fig, ax = plt.subplots(3, 2, figsize=(6, 8), sharex=True, sharey=True)
 
 
 # -----------------------------------------------------------
 # First extract states from file
 # -----------------------------------------------------------
-
-file = open("hBN_N30.kwf", "r")
+filename = sys.argv[1]
+file = open(filename, "r")
 lines = file.readlines()
 kpoints = []
 ks = []
@@ -53,7 +52,7 @@ file.close()
 # Sum densities over degeneracies
 # -----------------------------------------------------------
 
-degeneracies = [2, 1, 1, 2, 2]
+degeneracies = [1, 1, 1, 1, 1, 1, 1, 1]
 wfs = []
 counter = 0
 for deg in degeneracies:
@@ -66,30 +65,39 @@ for deg in degeneracies:
 # -----------------------------------------------------------
 # Plot states
 # -----------------------------------------------------------
+fig, ax = plt.subplots(4, 2, figsize=(6, 8), sharex=True, sharey=True)
 
 ax[0, 0].tripcolor(kpoints[:, 0], kpoints[:, 1], wfs[0], cmap="viridis")
 ax[0, 1].tripcolor(kpoints[:, 0], kpoints[:, 1], wfs[1], cmap="viridis")
 ax[1, 0].tripcolor(kpoints[:, 0], kpoints[:, 1], wfs[2], cmap="viridis")
 ax[1, 1].tripcolor(kpoints[:, 0], kpoints[:, 1], wfs[3], cmap="viridis")
 ax[2, 0].tripcolor(kpoints[:, 0], kpoints[:, 1], wfs[4], cmap="viridis")
+ax[2, 1].tripcolor(kpoints[:, 0], kpoints[:, 1], wfs[5], cmap="viridis")
+ax[3, 0].tripcolor(kpoints[:, 0], kpoints[:, 1], wfs[6], cmap="viridis")
+ax[3, 1].tripcolor(kpoints[:, 0], kpoints[:, 1], wfs[7], cmap="viridis")
 
 for axis_row in ax:
     for axis in axis_row:
         axis.axis("square")
-ax[2, 1].axis("off")
+# ax[2, 1].axis("off")
 
-xlim = 2.4
-ax[0, 0].set_ylim([-xlim, xlim])
+ylim = max(kpoints[:, 1])    
+ax[0, 0].set_ylim([-ylim, ylim])
+xlim = max(kpoints[:, 0])
 ax[0, 0].set_xlim([-xlim, xlim])
 # ax[0].set_xlabel(r"$k_x$ (\AA$^{-1}$)")
 
 ax[0, 0].set_ylabel(r"$k_y$ (\AA$^{-1}$)")
 ax[1, 0].set_ylabel(r"$k_y$ (\AA$^{-1}$)")
 ax[2, 0].set_ylabel(r"$k_y$ (\AA$^{-1}$)")
-ax[2, 0].set_xlabel(r"$k_x$ (\AA$^{-1}$)")
-ax[1, 1].set_xlabel(r"$k_x$ (\AA$^{-1}$)")
-ax[1, 1].set_xticks([-2, 0, 2])
+ax[3, 0].set_ylabel(r"$k_y$ (\AA$^{-1}$)")
+ax[3, 0].set_xlabel(r"$k_x$ (\AA$^{-1}$)")
+ax[3, 1].set_xlabel(r"$k_x$ (\AA$^{-1}$)")
+ax[1, 1].set_xticks([-xlim, 0, xlim])
 
 ax[1,1].tick_params(labelbottom=True)
 
-plt.show()
+plt.tight_layout()
+plt.savefig("kwf.png", dpi=600)
+plt.savefig("kwf.pdf", dpi=600)
+# plt.show()

--- a/src/ExcitonTB.cpp
+++ b/src/ExcitonTB.cpp
@@ -392,16 +392,16 @@ double ExcitonTB::keldysh(arma::rowvec r){
     double SH0;
     double cutoff = arma::norm(system->bravaisLattice.row(0)) * cutoff_ + 1E-5;
     arma::rowvec R0 = {r0,ry,rz};
-    double R = abs(arma::norm(r/R0));
+    double R = arma::norm(r/R0);
+    double r_norm = arma::norm(r);
     double r0avg = (r0 + ry + rz)/3;
-    double r0norm = abs(arma::norm(R0));
     double potential_value;
-    if(R == 0){
+    if(r_norm < 1E-10){
         STVH0(regularization/r0, &SH0);
         potential_value = ec/(8E-10*eps0*eps_bar*r0avg)*(SH0 - y0(regularization/r0avg));
         // potential_value = ec/(8E-10*eps0*eps_bar*r0norm)*(SH0 - y0(regularization/r0norm));
     }
-    else if (R > cutoff){
+    else if (r_norm > cutoff){
         potential_value = 0.0;
     }
     else{

--- a/src/ExcitonTB.cpp
+++ b/src/ExcitonTB.cpp
@@ -393,17 +393,18 @@ double ExcitonTB::keldysh(arma::rowvec r){
     double cutoff = arma::norm(system->bravaisLattice.row(0)) * cutoff_ + 1E-5;
     arma::rowvec R0 = {r0,ry,rz};
     double R = abs(arma::norm(r/R0));
+    double r0avg = (r0 + ry + rz)/3;
     double potential_value;
     if(R == 0){
         STVH0(regularization/r0, &SH0);
-        potential_value = ec/(8E-10*eps0*eps_bar*r0)*(SH0 - y0(regularization/r0));
+        potential_value = ec/(8E-10*eps0*eps_bar*r0avg)*(SH0 - y0(regularization/r0avg));
     }
     else if (R > cutoff){
         potential_value = 0.0;
     }
     else{
         STVH0(R, &SH0);
-        potential_value = ec/(8E-10*eps0*eps_bar*r0)*(SH0 - y0(R));
+        potential_value = ec/(8E-10*eps0*eps_bar*r0avg)*(SH0 - y0(R));
     };
 
     return potential_value;

--- a/src/ExcitonTB.cpp
+++ b/src/ExcitonTB.cpp
@@ -399,7 +399,6 @@ double ExcitonTB::keldysh(arma::rowvec r){
     if(r_norm < 1E-10){
         STVH0(regularization/r0, &SH0);
         potential_value = ec/(8E-10*eps0*eps_bar*r0avg)*(SH0 - y0(regularization/r0avg));
-        // potential_value = ec/(8E-10*eps0*eps_bar*r0norm)*(SH0 - y0(regularization/r0norm));
     }
     else if (r_norm > cutoff){
         potential_value = 0.0;
@@ -407,7 +406,6 @@ double ExcitonTB::keldysh(arma::rowvec r){
     else{
         STVH0(R, &SH0);
         potential_value = ec/(8E-10*eps0*eps_bar*r0avg)*(SH0 - y0(R));
-        // potential_value = ec/(8E-10*eps0*eps_bar*r0norm)*(SH0 - y0(R));
     };
 
     return potential_value;

--- a/src/ExcitonTB.cpp
+++ b/src/ExcitonTB.cpp
@@ -428,57 +428,6 @@ double ExcitonTB::coulomb(arma::rowvec r){
     return (R != 0) ? ec/(4E-10*PI*eps0*R) : ec*1E10/(4*PI*eps0*regularization);    
 }
 
-// Calculates epsilon(q) for quasi-2D RK real-space potential
-// double ExcitonTB::epsilon_q(arma::rowvec q) {
-//     // reflection coeffs
-//     double pt = (eps_m - 1)/(eps_m + 1);
-//     double pb = (eps_s - 1)/(eps_s + 1);
-
-//     double e_qd2 = std::exp(-q*d/2);
-//     double e_qd  = e_qd2*e_qd2;
-
-//     // denominators
-//     double Dt = 1 + q*r0
-//                 - q*r0*(1+pt)*e_qd2
-//                 - (1 - q*r0)*pt*e_qd;
-//     double Db = 1 + q*r0
-//                 - q*r0*(1+pb)*e_qd2
-//                 - (1 - q*r0)*pb*e_qd;
-
-//     // numerators
-//     double Nt = (1+q*r0)*(1+q*r0z)
-//                 + ((1-pt) - (1+pt)*q*r0z)*q*r0*e_qd2
-//                 + (1-q*r0)*(1-q*r0z)*pt*e_qd;
-//     double Nb = (1+q*r0)*(1+q*r0z)
-//                 + ((1-pb) - (1+pb)*q*r0z)*q*r0*e_qd2
-//                 + (1-q*r0)*(1-q*r0z)*pb*e_qd;
-
-//     return 0.5*(Nt/Dt + Nb/Db);
-// }
-
-/*
-    Quasi-2D Rytova-Keldysh potential in Real space 
-    as in VanTuan2018 DOI: 10.1103/PhysRevB.98.125308
-*/
-// double ExcitonTB::Q2DRK(double r){
-//     // Pre-factor e^2/(2π eps_0)
-//     double pref = e_charge*e_charge/(2*pi*eps0);
-
-//     // Set up trapezoidal grid in q
-//     double dq = q_max / (Nq-1);
-//     double sum = 0.0;
-
-//     for(int i=0; i < Nq; i++){
-//         double q    = i * dq;
-//         double wgt  = (i == 0 || i == Nq-1 ? 0.5 : 1.0);
-//         double eps  = epsilon_q(q);
-//         double J0   = boost::math::cyl_bessel_j(0, q*r);
-//         sum += wgt * q * J0 / eps;
-//     }
-
-//     return pref * sum * dq;
-// }
-
 /**
  * Method to select the potential to be used in the of the exciton calculation.
  * @param potential Potential to be used in the direct term.

--- a/src/ExcitonTB.cpp
+++ b/src/ExcitonTB.cpp
@@ -394,10 +394,12 @@ double ExcitonTB::keldysh(arma::rowvec r){
     arma::rowvec R0 = {r0,ry,rz};
     double R = abs(arma::norm(r/R0));
     double r0avg = (r0 + ry + rz)/3;
+    double r0norm = abs(arma::norm(R0));
     double potential_value;
     if(R == 0){
         STVH0(regularization/r0, &SH0);
         potential_value = ec/(8E-10*eps0*eps_bar*r0avg)*(SH0 - y0(regularization/r0avg));
+        // potential_value = ec/(8E-10*eps0*eps_bar*r0norm)*(SH0 - y0(regularization/r0norm));
     }
     else if (R > cutoff){
         potential_value = 0.0;
@@ -405,6 +407,7 @@ double ExcitonTB::keldysh(arma::rowvec r){
     else{
         STVH0(R, &SH0);
         potential_value = ec/(8E-10*eps0*eps_bar*r0avg)*(SH0 - y0(R));
+        // potential_value = ec/(8E-10*eps0*eps_bar*r0norm)*(SH0 - y0(R));
     };
 
     return potential_value;

--- a/src/ResultTB.cpp
+++ b/src/ResultTB.cpp
@@ -318,13 +318,14 @@ arma::cx_mat ResultTB::excitonOscillatorStrength(){
     arma::cx_cube vme_ex = arma::zeros<arma::cx_cube>(3, norb_ex, 2);
 
     std::complex<double>* vme = new std::complex<double>[3*nk*(nv + nc)*(nv + nc)];
-    bool convert_to_au = true;
+    int convert_to_au = 1;
 
     exciton_oscillator_strength_(&nR, &norb, &norb_ex, &nv, &nc, &filling, 
              Rvec.memptr(), R.memptr(), extendedMotifFull.memptr(), hhop.memptr(), shop.memptr(), &nk, rkx.memptr(),
              rky.memptr(), rkz.memptr(), m_eigvec.memptr(), m_eigval.memptr(), eigval_sp.memptr(), eigvec_sp.memptr(),
              vme, vme_ex.memptr(), &convert_to_au);
 
+    delete[] vme;
     return vme_ex.slice(0);
 }
 

--- a/src/skubo_w.f90
+++ b/src/skubo_w.f90
@@ -694,16 +694,8 @@ do iw=1,nw
       do nj=1,3
         do njp=1,3
           skubo=vme(nj,nn,nnp)*vme(njp,nnp,nn)
-          if (nj == 3 .OR. njp == 3 .AND. nj /= njp) then
-            sigma_w_sp(nj,njp,iw)=sigma_w_sp(nj,njp,iw)+ &
-            pi/(dble(npointstotal)*vcell)*factor1*skubo*delta_nnp*(e(nn)-e(nnp))
-          else if (nj == 3 .AND. njp == 3) then
-            sigma_w_sp(nj,njp,iw)=sigma_w_sp(nj,njp,iw)+ &
-            pi/(dble(npointstotal)*vcell)*factor1*skubo*delta_nnp*(e(nn)-e(nnp))**2
-          else
-            sigma_w_sp(nj,njp,iw)=sigma_w_sp(nj,njp,iw)+ &
-            pi/(dble(npointstotal)*vcell)*factor1*skubo*delta_nnp
-          end if
+          sigma_w_sp(nj,njp,iw)=sigma_w_sp(nj,njp,iw)+ &
+          pi/(dble(npointstotal)*vcell)*factor1*skubo*delta_nnp
         end do
       end do
     		  

--- a/src/skubo_w.f90
+++ b/src/skubo_w.f90
@@ -3,7 +3,7 @@ subroutine skubo_w(nR,norb,norb_ex,nv_ex,nc_ex,nv,Rvec,R,B,hhop,shop,npointstota
 rky,rkz,fk_ex,e_ex,eigval_stack,eigvec_stack)
 implicit real*8 (a-h,o-z)
 
-!out of subroutine arrays 
+!out of subroutine arrays
 dimension Rvec(nR,3)
 dimension R(3,3)
 dimension hhop(norb,norb,nR)
@@ -26,7 +26,7 @@ allocatable vme(:,:,:,:)
 allocatable sigma_w_sp(:,:,:)
 
 !exciton arrays
-allocatable vme_ex(:,:,:)  
+allocatable vme_ex(:,:,:)
 allocatable wp(:)
 allocatable skubo_ex_int(:,:,:)
 allocatable sigma_w_ex(:,:,:)
@@ -36,8 +36,8 @@ complex*16 fk_ex
 complex*16 eigvec_stack
 complex*16 hk_ev
 complex*16 vme
-complex*16 vme_ex 
-complex*16 skubo_ex_int 
+complex*16 vme_ex
+complex*16 skubo_ex_int
 complex*16 sigma_w_sp
 complex*16 sigma_w_ex
 
@@ -57,8 +57,8 @@ nbands = nv_ex + nc_ex
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !Here we work in atomic units
 Rvec=Rvec/0.52917721067121d0
-B=B/0.52917721067121d0 
-R=R/0.52917721067121d0 
+B=B/0.52917721067121d0
+R=R/0.52917721067121d0
 hhop=hhop/27.211385d0
 rkx=rkx*0.52917721067121d0
 rky=rky*0.52917721067121d0
@@ -67,7 +67,7 @@ e_ex=e_ex/27.211385d0
 eigval_stack=eigval_stack/27.211385d0
 
 call crossproduct(R(1,1),R(1,2),R(1,3),R(2,1), &
-R(2,2),R(2,3),cx,cy,cz)         
+R(2,2),R(2,3),cx,cy,cz)
 vcell=sqrt(cx**2+cy**2+cz**2)
 
 !call fill_nRvec(nR,R,Rvec,nRvec)
@@ -75,7 +75,7 @@ vcell=sqrt(cx**2+cy**2+cz**2)
 call get_kubo_parameters(w0,wrange,nw,eta,type_broad, &
 file_name_sp,file_name_ex)
 eta=eta/27.211385d0
- 
+
 !SP arrays
 allocate (wp(nw))
 allocate (sigma_w_sp(3,3,nw))
@@ -87,11 +87,11 @@ wn_sp=0.0d0
 sigma_w_sp=0.0d0
 do i=1,nw
   wp(i)=(w0+wrange/dble(nw)*dble(i-1))/27.211385d0
-end do  
+end do
 
 !exciton arrays
-norb_ex_band=nv_ex*nc_ex !number of electron-hole pairs per k-point 
-norb_ex_cut=norb_ex  !total number of optical transitions 
+norb_ex_band=nv_ex*nc_ex !number of electron-hole pairs per k-point
+norb_ex_cut=norb_ex  !total number of optical transitions
 allocate (vme_ex(3,norb_ex_cut,2))
 allocate (sigma_w_ex(3,3,nw))
 allocate (skubo_ex_int(3,3,norb_ex_cut))
@@ -106,10 +106,10 @@ call exciton_oscillator_strength(nR,norb,norb_ex,nv_ex,nc_ex,nv,Rvec,R,B,hhop,sh
 ! Obtain SP Kubo
 do ibz=1,npointstotal
   e(:) = eigval_stack(:, ibz)
-          
+
   !get strength for kubo SP
   call get_kubo_intens(nv_ex,npointstotal,vcell,nbands,e,vme(ibz, :, :, :),nw,wp,sigma_w_sp,eta)
-  
+
 end do
 
 
@@ -121,7 +121,7 @@ do nn=1,norb_ex_cut
       skubo_ex_int(nj,njp,nn)=pi/(dble(npointstotal)*vcell) &
       *conjg(vme_ex(nj,nn,1))*vme_ex(njp,nn,1)/e_ex(nn)   !pick the correct order of operators
     end do
-  end do 
+  end do
 end do
 
 
@@ -131,16 +131,17 @@ do ialpha=1,3
     call broad_vector(type_broad,norb_ex_cut,e_ex,skubo_ex_int(ialpha,ialphap,:), &
     nw,wp,sigma_w_ex(ialpha,ialphap,:),eta)
   end do
-end do 
- 
-!write frequency dependent conductivity	  
+end do
+
+!write frequency dependent conductivity
 open(50,file=file_name_sp)
 open(60,file=file_name_ex)
 do iw=1,nw
   feps=1.0d0
   !feps=4.0d0*pi*1.0d0/137.035999084d0*100.0d0   !absorbance units
   !eps=4.0d0   !\sigma_0 units
-  write(50,*) wp(iw)*27.211385d0,-realpart(feps*sigma_w_sp(1,1,iw)), &
+  write(50,*) wp(iw)*27.211385d0, &
+              -realpart(feps*sigma_w_sp(1,1,iw)), &
               -realpart(feps*sigma_w_sp(1,2,iw)), &
               -realpart(feps*sigma_w_sp(1,3,iw)), &
               -realpart(feps*sigma_w_sp(2,1,iw)), &
@@ -148,16 +149,17 @@ do iw=1,nw
               -realpart(feps*sigma_w_sp(2,3,iw)), &
               -realpart(feps*sigma_w_sp(3,1,iw)), &
               -realpart(feps*sigma_w_sp(3,2,iw)), &
-              -realpart(feps*sigma_w_sp(3,3,iw))                
-  write(60,*) wp(iw)*27.211385d0,realpart(feps*sigma_w_ex(1,1,iw)), &
-              realpart(feps*sigma_w_ex(1,2,iw)), &
-              realpart(feps*sigma_w_ex(1,3,iw)), &
-              realpart(feps*sigma_w_ex(2,1,iw)), &
-              realpart(feps*sigma_w_ex(2,2,iw)), &
-              realpart(feps*sigma_w_ex(2,3,iw)), &
-              realpart(feps*sigma_w_ex(3,1,iw)), &
-              realpart(feps*sigma_w_ex(3,2,iw)), &	
-              realpart(feps*sigma_w_ex(3,3,iw))
+              -realpart(feps*sigma_w_sp(3,3,iw))
+  write(60,*) wp(iw)*27.211385d0, &
+              realpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(1,1,iw)), &
+              realpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(1,2,iw)), &
+              realpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(1,3,iw)), &
+              realpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(2,1,iw)), &
+              realpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(2,2,iw)), &
+              realpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(2,3,iw)), &
+              realpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(3,1,iw)), &
+              realpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(3,2,iw)), &
+              realpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(3,3,iw))
 end do
 
 close(50)
@@ -174,14 +176,15 @@ else
   file_name_ex_imag = file_name_ex(:p_dot-1)//'_imag'//file_name_ex(p_dot:)
 endif
 
-!write imaginary part of frequency dependent conductivity   
-open(50,file=file_name_sp_imag) 
-open(60,file=file_name_ex_imag) 
+!write imaginary part of frequency dependent conductivity
+open(50,file=file_name_sp_imag)
+open(60,file=file_name_ex_imag)
 do iw=1,nw
   feps=1.0d0
   !feps=4.0d0*pi*1.0d0/137.035999084d0*100.0d0   !absorbance units
   !eps=4.0d0   !\sigma_0 units
-  write(50,*) wp(iw)*27.211385d0,-imagpart(feps*sigma_w_sp(1,1,iw)), &
+  write(50,*) wp(iw)*27.211385d0, &
+              -imagpart(feps*sigma_w_sp(1,1,iw)), &
               -imagpart(feps*sigma_w_sp(1,2,iw)), &
               -imagpart(feps*sigma_w_sp(1,3,iw)), &
               -imagpart(feps*sigma_w_sp(2,1,iw)), &
@@ -189,16 +192,17 @@ do iw=1,nw
               -imagpart(feps*sigma_w_sp(2,3,iw)), &
               -imagpart(feps*sigma_w_sp(3,1,iw)), &
               -imagpart(feps*sigma_w_sp(3,2,iw)), &
-              -imagpart(feps*sigma_w_sp(3,3,iw))                
-  write(60,*) wp(iw)*27.211385d0,imagpart(feps*sigma_w_ex(1,1,iw)), &
-              imagpart(feps*sigma_w_ex(1,2,iw)), &
-              imagpart(feps*sigma_w_ex(1,3,iw)), &
-              imagpart(feps*sigma_w_ex(2,1,iw)), &
-              imagpart(feps*sigma_w_ex(2,2,iw)), &
-              imagpart(feps*sigma_w_ex(2,3,iw)), &
-              imagpart(feps*sigma_w_ex(3,1,iw)), &
-              imagpart(feps*sigma_w_ex(3,2,iw)), &  
-              imagpart(feps*sigma_w_ex(3,3,iw))
+              -imagpart(feps*sigma_w_sp(3,3,iw))
+  write(60,*) wp(iw)*27.211385d0, &
+              imagpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(1,1,iw)), &
+              imagpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(1,2,iw)), &
+              imagpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(1,3,iw)), &
+              imagpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(2,1,iw)), &
+              imagpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(2,2,iw)), &
+              imagpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(2,3,iw)), &
+              imagpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(3,1,iw)), &
+              imagpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(3,2,iw)), &
+              imagpart(complex(0.0d0,-1.0d0)*feps*sigma_w_ex(3,3,iw))
 end do
 
 close(50)
@@ -236,8 +240,8 @@ end
 subroutine exciton_oscillator_strength(nR,norb,norb_ex,nv_ex,nc_ex,nv,Rvec,R,B,hhop,shop,npointstotal,rkx, &
   rky,rkz,fk_ex,e_ex,eigval_stack,eigvec_stack,vme,vme_ex,convert_to_au)
   implicit real*8 (a-h,o-z)
-  
-  !out of subroutine arrays 
+
+  !out of subroutine arrays
   dimension Rvec(nR,3)
   dimension R(3,3)
   dimension hhop(norb,norb,nR)
@@ -253,7 +257,7 @@ subroutine exciton_oscillator_strength(nR,norb,norb_ex,nv_ex,nc_ex,nv,Rvec,R,B,h
   dimension eigvec_stack(norb,nv_ex + nc_ex,npointstotal)
   dimension vme_ex(3,norb_ex,2)
   dimension vme(npointstotal,3,nv_ex + nc_ex,nv_ex + nc_ex)
-  
+
   !sp and exciton variables
   allocatable sderhop(:,:,:,:)
   allocatable hderhop(:,:,:,:)
@@ -262,13 +266,13 @@ subroutine exciton_oscillator_strength(nR,norb,norb_ex,nv_ex,nc_ex,nv,Rvec,R,B,h
   allocatable hderkernel(:,:,:)
   allocatable sderkernel(:,:,:)
   allocatable akernel(:,:,:)
-  allocatable pgaugekernel(:,:,:)  
+  allocatable pgaugekernel(:,:,:)
   allocatable hk_ev(:,:)
   allocatable e(:)
   allocatable pgauge(:,:,:)
-  allocatable vjseudoa(:,:,:) 
-  allocatable vjseudob(:,:,:)  
-  
+  allocatable vjseudoa(:,:,:)
+  allocatable vjseudob(:,:,:)
+
   complex*16 hhop
   complex*16 sderhop
   complex*16 hderhop
@@ -285,15 +289,15 @@ subroutine exciton_oscillator_strength(nR,norb,norb_ex,nv_ex,nc_ex,nv,Rvec,R,B,h
   complex*16 vjseudoa
   complex*16 vjseudob
   complex*16 vme
-  complex*16 vme_ex 
+  complex*16 vme_ex
 
   logical convert_to_au
 
 
   if (convert_to_au) then
     Rvec=Rvec/0.52917721067121d0
-    B=B/0.52917721067121d0 
-    R=R/0.52917721067121d0 
+    B=B/0.52917721067121d0
+    R=R/0.52917721067121d0
     hhop=hhop/27.211385d0
     rkx=rkx*0.52917721067121d0
     rky=rky*0.52917721067121d0
@@ -303,14 +307,14 @@ subroutine exciton_oscillator_strength(nR,norb,norb_ex,nv_ex,nc_ex,nv,Rvec,R,B,h
   end if
 
   nbands = nv_ex + nc_ex
-  
+
   pi=acos(-1.0d0)
-      
+
   !get unit cell volume
   call crossproduct(R(1,1),R(1,2),R(1,3),R(2,1), &
-  R(2,2),R(2,3),cx,cy,cz)         
+  R(2,2),R(2,3),cx,cy,cz)
   vcell=sqrt(cx**2+cy**2+cz**2)
-   
+
   !SP arrays
   allocate (sderhop(3,nR,norb,norb))
   allocate (hderhop(3,nR,norb,norb))
@@ -319,19 +323,19 @@ subroutine exciton_oscillator_strength(nR,norb,norb_ex,nv_ex,nc_ex,nv,Rvec,R,B,h
   allocate (hderkernel(3,norb,norb))
   allocate (sderkernel(3,norb,norb))
   allocate (akernel(3,norb,norb))
-  allocate (pgaugekernel(3,norb,norb))  
+  allocate (pgaugekernel(3,norb,norb))
   allocate (hk_ev(norb,nbands))
   allocate (e(nbands))
   allocate (pgauge(3,nbands,nbands))
-  allocate (vjseudoa(3,nbands,nbands)) 
+  allocate (vjseudoa(3,nbands,nbands))
   allocate (vjseudob(3,nbands,nbands))
-  
+
   !exciton arrays
-  norb_ex_band=nv_ex*nc_ex !number of electron-hole pairs per k-point 
-  norb_ex_cut=norb_ex  !total number of optical transitions 
+  norb_ex_band=nv_ex*nc_ex !number of electron-hole pairs per k-point
+  norb_ex_cut=norb_ex  !total number of optical transitions
 
   vme_ex=0.0d0
-  
+
 
   rhop=0.0d0
   do i = 1, nR
@@ -347,57 +351,57 @@ subroutine exciton_oscillator_strength(nR,norb,norb_ex,nv_ex,nc_ex,nv,Rvec,R,B,h
 
   !getting some SP variables
   call hoppings_observables_TB(norb,nR,Rvec,shop,hhop,rhop,sderhop,hderhop)
-  !11/05/2023 JJEP: fill rhop here. Easier to extend to DFT later 
+  !11/05/2023 JJEP: fill rhop here. Easier to extend to DFT later
 
-  !Brillouin zone sampling	  
+  !Brillouin zone sampling
   !!$OMP PARALLEL DO PRIVATE(rkxp,rkyp,rkzp), &
-  !!$OMP PRIVATE(hkernel,skernel,sderkernel,hderkernel,akernel), &  
+  !!$OMP PRIVATE(hkernel,skernel,sderkernel,hderkernel,akernel), &
   !!$OMP PRIVATE(hk_ev,e,pgaugekernel,pgauge,vjseudoa,vjseudob,vme), &
   !!$OMP PRIVATE(nj,iex,ib,nv_ip,nc_ip,j)
   do ibz=1,npointstotal
-    !write(*,*) 'point:',ibz,npointstotal         
+    !write(*,*) 'point:',ibz,npointstotal
     rkxp=rkx(ibz)
     rkyp=rky(ibz)
     rkzp=rkz(ibz)
-  
+
     hk_ev(:, :) = eigvec_stack(:, :, ibz)
     e(:) = eigval_stack(:, ibz)
-            
-    !get matrices in the \alpha, \alpha' basis (orbitals,k)    		
+
+    !get matrices in the \alpha, \alpha' basis (orbitals,k)
     call get_vme_kernels(rkxp,rkyp,rkzp,nR,Rvec,norb,hkernel,skernel,shop, &
     hhop,rhop,sderhop,hderhop,sderkernel,hderkernel,akernel,pgaugekernel)
     !velocity matrix elements
     call get_eigen_vme(norb,nbands,skernel,hkernel,akernel,hderkernel, &
-    pgaugekernel,hk_ev,e,pgauge,vjseudoa,vjseudob,vme(ibz, :, :, :)) 
+    pgaugekernel,hk_ev,e,pgauge,vjseudoa,vjseudob,vme(ibz, :, :, :))
 
     !fill V_N
-    !!$OMP critical	
+    !!$OMP critical
     do nj=1,3
       do iex=1,norb_ex_cut
         !!! Iterate over band index explicitly (AJU 03-06-23)
         do ic=1,nc_ex
         do iv=1,nv_ex
-        
+
           j = nc_ex * nv_ex * (ibz - 1) + nv_ex * (ic - 1) + iv
-          !get valence/conduction indices      
+          !get valence/conduction indices
           !nv_ip=(nv-nv_ex)+ib-int((ib-1)/nv_ex)*nv_ex
           !nc_ip=(nv+1)+int((ib-1)/nv_ex)
           !j=(ibz-1)*norb_ex_band+ib
-      
+
           vme_ex(nj,iex,1)=vme_ex(nj,iex,1)+fk_ex(j,iex)*vme(ibz, nj,iv,ic + nv_ex)
           vme_ex(nj,iex,2)=vme_ex(nj,iex,2)+fk_ex(j,iex)*vme(ibz, nj,ic + nv_ex,iv)
-  
+
         end do
         end do
       end do
-    end do       
-    
+    end do
+
   end do
-  
+
   return
 end
-  
-  
+
+
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine fill_nRvec(nR,R,Rvec,nRvec)
 implicit real*8 (a-h,o-z)
@@ -437,10 +441,10 @@ do n3=-nz,nz !run n3 first (better for 2D)
   end do
 end do
 88 continue
-  
+
 return
 end
-  
+
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine get_kubo_parameters(w0,wrange,nw,eta,type_broad, &
 file_name_sp,file_name_ex)
@@ -455,23 +459,23 @@ open(10,file='kubo_w.in')
 read(10,*)
 read(10,*) w0
 read(10,*)
-read(10,*) wrange 
+read(10,*) wrange
 read(10,*)
 read(10,*) nw
-read(10,*) 
+read(10,*)
 read(10,*) eta
-read(10,*) 
+read(10,*)
 read(10,*) type_broad
-read(10,*)  
+read(10,*)
 read(10,*) file_name_sp
 read(10,*) file_name_ex
 close(10)
-    
+
 return
 end
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!    	  
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine hoppings_observables_TB(norb,nR,Rvec,shop,hhop, &
 rhop,sderhop,hderhop)
 
@@ -482,7 +486,7 @@ dimension sderhop(3,nR,norb,norb),hderhop(3,nR,norb,norb)
 
 complex*16 hhop
 complex*16 hderhop,sderhop
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!         
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 hderhop=0.0d0
 sderhop=0.0d0
 do iR=1,nR
@@ -494,7 +498,7 @@ do iR=1,nR
     ! Check if the z direction is defined (thus periodic)
     if (Rvec(iR,3) /= 0) then
       Rz = Rvec(iR,3)
-    else 
+    else
       Rz = rhop(3, iR, ialpha,ialphap) ! Quintela et. al. (2023) DOI: 10.1103/PhysRevB.107.235416
     end if
 
@@ -502,7 +506,7 @@ do iR=1,nR
     hderhop(1,iR,ialpha,ialphap)=complex(0.0d0,Rx)*hhop(ialpha,ialphap,iR)
     hderhop(2,iR,ialpha,ialphap)=complex(0.0d0,Ry)*hhop(ialpha,ialphap,iR)
     hderhop(3,iR,ialpha,ialphap)=complex(0.0d0,Rz)*hhop(ialpha,ialphap,iR)
-  
+
     sderhop(1,iR,ialpha,ialphap)=complex(0.0d0,Rx)*shop(ialpha,ialphap,iR)
     sderhop(2,iR,ialpha,ialphap)=complex(0.0d0,Ry)*shop(ialpha,ialphap,iR)
     sderhop(3,iR,ialpha,ialphap)=complex(0.0d0,Rz)*shop(ialpha,ialphap,iR)
@@ -517,7 +521,7 @@ return
 end
 
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   	        
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine get_vme_kernels(rkx,rky,rkz,nR,Rvec,norb, &
 hkernel,skernel,shop,hhop,rhop,sderhop,hderhop,sderkernel,hderkernel,akernel, &
 pgaugekernel)
@@ -543,7 +547,7 @@ complex*16 hderhop,sderhop
 complex*16 phase,factor,hkernel,skernel
 complex*16 sderkernel,hderkernel,akernel
 complex*16 pgaugekernel
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  	  	  
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !evaluate \alpha \alpha' matrices for a given k
 
 hkernel=0.0d0
@@ -553,7 +557,7 @@ sderkernel=0.0d0
 akernel=0.0d0
 pgaugekernel=0.0d0
 do ialpha=1,norb
-  do ialphap=1,ialpha   
+  do ialphap=1,ialpha
 
     do iRp=1,nR
       Rx=Rvec(iRp,1)
@@ -566,32 +570,32 @@ do ialpha=1,norb
       end if
 
       phase=complex(0.0d0,rkx*Rx+rky*Ry+rkz*Rz)
-      factor=exp(phase)     
-                
+      factor=exp(phase)
+
       hkernel(ialpha,ialphap)=hkernel(ialpha,ialphap)+ &
-      factor*hhop(ialpha,ialphap,iRp)                
+      factor*hhop(ialpha,ialphap,iRp)
       skernel(ialpha,ialphap)=skernel(ialpha,ialphap)+ &
       factor*shop(ialpha,ialphap,iRp)
-                
-      do nj=1,3 
+
+      do nj=1,3
         sderkernel(nj,ialpha,ialphap)=sderkernel(nj,ialpha,ialphap)+ &
         factor*sderhop(nj,iRp,ialpha,ialphap)
-    
+
         hderkernel(nj,ialpha,ialphap)=hderkernel(nj,ialpha,ialphap)+ &
-        factor*hderhop(nj,iRp,ialpha,ialphap) 
+        factor*hderhop(nj,iRp,ialpha,ialphap)
 
         akernel(nj,ialpha,ialphap)=akernel(nj,ialpha,ialphap)+ &
         factor*(rhop(nj,iRp,ialpha,ialphap)+ &
-        complex(0.0d0,1.0d0)*sderhop(nj,iRp,ialpha,ialphap))            
-      end do  
+        complex(0.0d0,1.0d0)*sderhop(nj,iRp,ialpha,ialphap))
+      end do
   end do
-    
+
   do nj=1,3
     pgaugekernel(nj,ialpha,ialphap)=hkernel(ialpha,ialphap)* &
     complex(0.0d0,1.0d0)* &
     (rhop(nj,1,ialphap,ialphap)-rhop(nj,1,ialpha,ialpha))
   end do
-    
+
   !complex conjugate
   do nj=1,3
     hkernel(ialphap,ialpha)=conjg(hkernel(ialpha,ialphap))
@@ -599,20 +603,20 @@ do ialpha=1,norb
     sderkernel(nj,ialphap,ialpha)=conjg(sderkernel(nj,ialpha,ialphap))
     hderkernel(nj,ialphap,ialpha)=conjg(hderkernel(nj,ialpha,ialphap))
     akernel(nj,ialphap,ialpha)=conjg(akernel(nj,ialpha,ialphap))+ &
-    complex(0.0d0,1.0d0)*conjg(sderkernel(nj,ialpha,ialphap))     
-    pgaugekernel(nj,ialphap,ialpha)=conjg(pgaugekernel(nj,ialpha,ialphap))        
+    complex(0.0d0,1.0d0)*conjg(sderkernel(nj,ialpha,ialphap))
+    pgaugekernel(nj,ialphap,ialpha)=conjg(pgaugekernel(nj,ialpha,ialphap))
   end do
-    
+
 end do
-end do  
-    
+end do
+
 return
 end
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   	        
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine get_eigen_vme(norb,nbands,skernel, &
 hkernel,akernel,hderkernel,pgaugekernel, &
-hk_ev,e,pgauge,vjseudoa,vjseudob,vme) 
+hk_ev,e,pgauge,vjseudoa,vjseudob,vme)
 
 implicit real*8 (a-h,o-z)
 
@@ -629,13 +633,13 @@ complex*16 skernel,hkernel,akernel,hderkernel
 complex*16 hk_ev,vjseudoa,vjseudob,vme,pgaugekernel,pgauge
 
 complex*16 amu,amup
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!	  
-  
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
 !!! Remove diagonalization; instead use stored eigvecs and eigvals (AJU 29-05-23)
 ! e=0.0d0
-! call diagoz(norb,e,hkernel) 
-! !call diagoz_arbg(norb,ecomplex,skernel,hkernel)             
-! !call order(norb,ecomplex,e,hkernel) 
+! call diagoz(norb,e,hkernel)
+! !call diagoz_arbg(norb,ecomplex,skernel,hkernel)
+! !call order(norb,ecomplex,e,hkernel)
 ! do ii=1,norb
 ! do jj=1,norb
 !   hk_ev(ii,jj)=hkernel(ii,jj)
@@ -648,7 +652,7 @@ complex*16 amu,amup
 !   do i=1,norb
 !     aux1=aux1+hk_ev(i,j)
 !   end do
-  
+
 !   !argument of the sym
 !   arg=atan2(aimag(aux1),realpart(aux1))
 !   factor=exp(complex(0.0d0,-arg))
@@ -656,10 +660,10 @@ complex*16 amu,amup
 !   do ii=1,norb
 !     hk_ev(ii,j)=hk_ev(ii,j)*factor
 ! 	!hk_ev(ii,j)=hk_ev(ii,j)*1.0d0
-!   end do      
-! end do   
+!   end do
+! end do
 
-!write(*,*) 'computing velocity matrix elements'      
+!write(*,*) 'computing velocity matrix elements'
 vme=0.0d0
 vjseudoa=0.0d0
 vjseudob=0.0d0
@@ -667,14 +671,14 @@ pgauge=0.0d0
 
 !$OMP PARALLEL DO
 do nn=1,nbands
-  
-do nnp=1,nn        
+
+do nnp=1,nn
   !momentums and A and B term
   do ialpha=1,norb
   do ialphap=1,norb
     amu=hk_ev(ialpha,nn)
     amup=hk_ev(ialphap,nnp)
-    do nj=1,3      
+    do nj=1,3
       pgauge(nj,nn,nnp)=pgauge(nj,nn,nnp)+ &
       conjg(amu)*amup*pgaugekernel(nj,ialpha,ialphap)
 
@@ -685,15 +689,15 @@ do nnp=1,nn
         vjseudoa(nj,nn,nnp)=vjseudoa(nj,nn,nnp)+ &
         conjg(amu)*amup*hderkernel(nj,ialpha,ialphap)
       end if
-        
+
       vjseudob(nj,nn,nnp)=vjseudob(nj,nn,nnp)+conjg(amu)*amup* &
       (e(nn)*akernel(nj,ialpha,ialphap)-e(nnp)*conjg(akernel(nj,ialphap,ialpha)))* &
-      complex(0.0d0,1.0d0)         
-    end do                      
+      complex(0.0d0,1.0d0)
+    end do
     !if (nn.eq.2 .and. nnp.eq.1) then
     !write(*,*) nn,nnp,ialpha,ialphap,akernel(2,ialpha,ialphap),conjg(akernel(2,ialphap,ialpha))
     !pause
-    !end if 
+    !end if
   end do
   end do
 
@@ -705,7 +709,7 @@ do nnp=1,nn
     vjseudoa(nj,nnp,nn)=conjg(vjseudoa(nj,nn,nnp))
     vjseudob(nj,nnp,nn)=conjg(vjseudob(nj,nn,nnp))
   end do
-          
+
 end do
 end do
 !$OMP END PARALLEL DO
@@ -723,8 +727,8 @@ dimension e(nbands)
 
 complex*16 vme,skubo,sigma_w_sp
 pi=acos(-1.0d0)
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!	  
-do iw=1,nw  
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+do iw=1,nw
   do nn=1,nbands
   !fermi disrtibution
     if (nn.le.nv) then
@@ -738,10 +742,10 @@ do iw=1,nw
         fnnp=1.0d0
       else
         fnnp=0.0d0
-      end if                    
+      end if
       !DEDICE PREFACTOR WITH OCCUPATION
       if (abs(fnn-fnnp).lt.0.1d0) then !UPDATE: energies removed from this factor
-        factor1=0.0d0         
+        factor1=0.0d0
       else
         factor1=(fnn-fnnp)/(e(nn)-e(nnp))
       end if
@@ -749,7 +753,7 @@ do iw=1,nw
       delta_nnp=1.0d0/pi*aimag(1.0d0/(wp(iw)-e(nn)+e(nnp)-complex(0.0d0,eta)))
 	  !exponential
     ! delta_nnp=1.0d0/eta*1.0d0/sqrt(2.0d0*pi)*exp(-0.5d0/(eta**2)*(wp(iw)-e(nn)+e(nnp))**2)
-	  
+
       !save oscillator stregths
       do nj=1,3
         do njp=1,3
@@ -758,16 +762,16 @@ do iw=1,nw
           pi/(dble(npointstotal)*vcell)*factor1*skubo*delta_nnp
         end do
       end do
-    		  
+
     end do
   end do
-end do  
+end do
 !pause
 
 return
 end
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!      
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine broad_vector(type_broad,n,wn,fn,nw,wp,fw_c,eta)
 
 implicit real*8 (a-h,o-z)
@@ -814,8 +818,8 @@ implicit real*8 (a-h,o-z)
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 cx=ay*bz-az*by
 cy=az*bx-ax*bz
-cz=ax*by-ay*bx     
-  
+cz=ax*by-ay*bx
+
 return
 end
 
@@ -827,7 +831,7 @@ end
 !                 h;  gives eigenvectors by columns as output
 !   DESCRIPTION:  this subroutine uses Lapack libraries to diagonalize
 !                 an hermitian complex matrix.
-!   
+!
 !     Juan Jose Esteve-Paredes                28.11.2017
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine diagoz(n,w,h)
@@ -843,7 +847,7 @@ character*1 JOBZ,UPLO
 JOBZ='V'
 UPLO='U'
 LWORK=2*n
-        
+
 call zheev(JOBZ, UPLO, n, h, n, w, WORK, LWORK, RWORK, INFO)
 return
 end
@@ -866,16 +870,16 @@ end
       implicit real*8 (a-h,o-z)
 !declarations, notice double precision
       complex*16 h(n,n),s(n,n),w(n),VL(n,n),VR(n,n),WORK(200*n)
-      complex*16 ALPHA(n),BETA(n)      
+      complex*16 ALPHA(n),BETA(n)
       dimension RWORK(8*n),wreal(n)
       dimension ereal(n)
       integer INFO
-      
+
       complex*16 haux(n,n),saux(n,n),ssuma
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       saux=s
       haux=h
-      !find the solution using the LAPACK routine ZGGEEV     
+      !find the solution using the LAPACK routine ZGGEEV
       !e=0.0d0
       !do i=1,3
         !write(*,*) (s(i,j),j=1,3)
@@ -891,7 +895,7 @@ end
         !write(*,*) ALPHA(i),BETA(i),w(i)
         !do j=1,n
           !h(i,j)=VR(i,j)
-        !end do 
+        !end do
       !end do
       !pause
 
@@ -907,7 +911,7 @@ end
         !write(*,*) ALPHA(i),BETA(i),w(i)
         !do j=1,n
           !h(i,j)=VR(i,j)
-        !end do 
+        !end do
         !write(*,*) wreal(i),h(i,1)
         !write(*,*) ALPHA(i),BETA(i),w(i)
       end do
@@ -919,18 +923,18 @@ end
             ssuma=ssuma+conjg(h(i,k))*h(j,k)*saux(i,j)
           end do
         end do
-        snorma=sqrt(realpart(ssuma)) 
-        h(:,k)=1.0d0/snorma*h(:,k)       
+        snorma=sqrt(realpart(ssuma))
+        h(:,k)=1.0d0/snorma*h(:,k)
         !if (k.eq.1) write(*,*) ssuma
       end do
-      
+
       !write(*,*) 'Diagonalization=',INFO
       if (INFO.ne.0) then
         write(*,*) 'Bad diagonalization'
         write(*,*) 'Eigenvalues/ground state coefficients'
         do i=1,n
           write(*,*) wreal(i),h(i,1)
-        end do        
+        end do
         open(91,file='h_matlab_real.dat')
         open(92,file='s_matlab_real.dat')
         open(93,file='h_matlab_imag.dat')
@@ -940,11 +944,11 @@ end
           write(92,*) (realpart(saux(i,j)), j=1,n)
           write(93,*) (aimag(haux(i,j)), j=1,n)
           write(94,*) (aimag(saux(i,j)), j=1,n)
-        end do 
+        end do
         close(91)
         close(92)
         close(93)
-        close(94)  
+        close(94)
         pause
       end if
       s=saux
@@ -952,7 +956,7 @@ end
         !write(*,*) i,h(i,1),w(i)
       !end do
       !pause
-    
+
       return
       end
 
@@ -968,13 +972,13 @@ end
      do i=1,n
        eaux(i)=realpart(ecomplex(i))
      end do
-     
+
      do i=1,n
-       imin=minloc(eaux,1)      
+       imin=minloc(eaux,1)
        e(i)=eaux(imin)
        hk(:,i)=hkaux(:,imin)
        eaux(imin)=1.0d8
      end do
-    
+
      return
      end

--- a/src/skubo_w.f90
+++ b/src/skubo_w.f90
@@ -166,10 +166,10 @@ close(60)
 p_dot = scan(file_name_ex, '.', .true.)           ! find first “.” from the right
 if (p_dot == 0) then
   ! no “.” found, just append
-  file_name_strength = trim(file_name_ex)//'_strength'
+  file_name_strength = trim(file_name_ex)//'_osc'
 else
   ! insert '_strength' before the dot
-  file_name_strength = file_name_ex(:p_dot-1)//'_strength'//file_name_ex(p_dot:)
+  file_name_strength = file_name_ex(:p_dot-1)//'_osc'//file_name_ex(p_dot:)
 endif
 
 ! write exciton oscillator strengths to a separate file

--- a/src/skubo_w.f90
+++ b/src/skubo_w.f90
@@ -31,7 +31,6 @@ allocatable wp(:)
 allocatable skubo_ex_int(:,:,:)
 allocatable sigma_w_ex(:,:,:)
 
-
 complex*16 hhop
 complex*16 fk_ex
 complex*16 eigvec_stack
@@ -45,6 +44,8 @@ complex*16 sigma_w_ex
 character(100) type_broad
 character(100) file_name_sp
 character(100) file_name_ex
+character(len=:), allocatable :: file_name_strength
+integer :: p_dot
 
 
 pi=acos(-1.0d0)
@@ -157,17 +158,33 @@ do iw=1,nw
               realpart(feps*sigma_w_ex(3,3,iw))
 end do
 
-!write exciton oscillator strengths
-norb_ex_cut=nv_ex*nc_ex*npointstotal
-write(60,*) '' ! Empty line
-do iex=1,norb_ex_cut
-  write(60,*) e_ex(iex)*27.211385d0,realpart(vme_ex(1,iex,1)), imagpart(vme_ex(1,iex,1)), &
-              realpart(vme_ex(2,iex,1)), imagpart(vme_ex(2,iex,1)), &
-              realpart(vme_ex(3,iex,1)), imagpart(vme_ex(3,iex,1))
-end do
-
 close(50)
 close(60)
+
+! Oscillator stregth: append name to exciton spectra
+! assume file_name_ex has been set, e.g. 'some_file.dat'
+p_dot = scan(file_name_ex, '.', .true.)           ! find first “.” from the right
+if (p_dot == 0) then
+  ! no “.” found, just append
+  file_name_strength = trim(file_name_ex)//'_strength'
+else
+  ! insert '_strength' before the dot
+  file_name_strength = file_name_ex(:p_dot-1)//'_strength'//file_name_ex(p_dot:)
+endif
+
+! write exciton oscillator strengths to a separate file
+open(unit=70, file=file_name_strength)
+
+norb_ex_cut = nv_ex*nc_ex*npointstotal
+do iex=1,norb_ex_cut
+  write(70,*) e_ex(iex)*27.211385d0, realpart(vme_ex(1,iex,1)), &
+               imagpart(vme_ex(1,iex,1)), &
+               realpart(vme_ex(2,iex,1)), imagpart(vme_ex(2,iex,1)), &
+               realpart(vme_ex(3,iex,1)), imagpart(vme_ex(3,iex,1))
+end do
+
+close(70)
+
 
 return
 end

--- a/src/skubo_w.f90
+++ b/src/skubo_w.f90
@@ -452,7 +452,7 @@ do iR=1,nR
     if (Rvec(iR,3) /= 0) then
       Rz = Rvec(iR,3)
     else 
-      Rz=rhop(3, iR, ialpha,ialphap)
+      Rz = rhop(3, iR, ialpha,ialphap) ! Quintela et. al. (2023) DOI: 10.1103/PhysRevB.107.235416
     end if
 
 

--- a/src/skubo_w.f90
+++ b/src/skubo_w.f90
@@ -669,9 +669,9 @@ vjseudoa=0.0d0
 vjseudob=0.0d0
 pgauge=0.0d0
 
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO &
+!$OMP& PRIVATE(nnp,ialpha,ialphap,nj,amu,amup)
 do nn=1,nbands
-
 do nnp=1,nn
   !momentums and A and B term
   do ialpha=1,norb

--- a/test/data/hBN_anisotropic.txt
+++ b/test/data/hBN_anisotropic.txt
@@ -1,0 +1,11 @@
+# label
+! Name to be used when writing
+hBN_ani
+# ncells
+! Number of unit cells along each direction
+30
+# bands
+1
+# Dielectric
+1 1 10 25 35
+#

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -798,8 +798,8 @@ TEST_CASE("TB hBN absorption - anisotropic", "[tb-hBN-kubo-ani]"){
     arma::mat norm_vme_ex = arma::square(arma::abs(vme_ex));
     double cum_norm_vme_ex = arma::accu(norm_vme_ex);
 
-    double expectedTotalOscillator = 47.4140063784;
-    REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-7));
+    double expectedTotalOscillator = 47.4140064;
+    REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-6));
 
 }
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -18,11 +18,11 @@
 
 TEST_CASE("Modelfile parsing", "[model_parsing]"){
 
-    std::cout << std::setw(40) << std::left << "Testing model file parsing... ";
+    std::cout << std::setw(50) << std::left << "Testing model file parsing... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
     
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     int expectedFilling = 1;
     int expectedDim = 2;
@@ -55,19 +55,16 @@ TEST_CASE("Modelfile parsing", "[model_parsing]"){
         double hash = xatu::array2hash(config.systemInfo.hamiltonian.slice(i));
         REQUIRE_THAT(hash, Catch::Matchers::WithinAbs(expectedHamiltionianHash(i), 1E-4));
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("CRYSTAL file parsing", "[CRYSTAL_parsing]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing CRYSTAL file parsing... ";
+    std::cout << std::setw(50) << std::left << "Testing CRYSTAL file parsing... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     std::string modelfile = "../examples/material_models/DFT/hBN_base_HSE06.outp";
-    xatu::CRYSTALConfiguration config = xatu::CRYSTALConfiguration(modelfile);
+    xatu::CRYSTALConfiguration config(modelfile);
 
     int expectedFilling = 6;
     int expectedDim = 2;
@@ -117,20 +114,17 @@ TEST_CASE("CRYSTAL file parsing", "[CRYSTAL_parsing]"){
         double hash = xatu::array2hash(config.systemInfo.overlap.slice(i));
         REQUIRE_THAT(hash, Catch::Matchers::WithinAbs(expectedOverlapHash(i), 1E-2));
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("Wannier90 file parsing", "[wannier_parsing]") {
     // Suppress output during test
-    std::cout << std::setw(40) << std::left << "Testing Wannier90 file parsing... ";
+    std::cout << std::setw(50) << std::left << "Testing Wannier90 file parsing... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     // Load Wannier90 file
     std::string modelfile = "../examples/material_models/wannier/hBN_tb.dat";
     std::cout << "got file: " << modelfile << std::endl;
-    xatu::Wannier90Configuration config = xatu::Wannier90Configuration(modelfile, 4);
+    xatu::Wannier90Configuration config(modelfile, 4);
 
     int expectedDim = 2;                         // Dimension of the system
     int expectedFilling = 4;                     // Number of filled states
@@ -243,20 +237,16 @@ TEST_CASE("Wannier90 file parsing", "[wannier_parsing]") {
             hashIndex++;
         }
     }
-
-    // Restore output
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("Exciton file parsing", "[excitonfile_parsing]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing exciton file parsing... ";
+    std::cout << std::setw(50) << std::left << "Testing exciton file parsing... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     std::string excitonconfig = "./data/hBN_spinless.txt";
-    xatu::ExcitonConfiguration config = xatu::ExcitonConfiguration(excitonconfig);
+    xatu::ExcitonConfiguration config(excitonconfig);
 
     std::string expectedName = "hBN_N30";
     int expectedNcell = 30;
@@ -269,19 +259,16 @@ TEST_CASE("Exciton file parsing", "[excitonfile_parsing]"){
         REQUIRE(config.excitonInfo.eps(i) == expectedDielectric(i));
     }
     REQUIRE(xatu::array2hash(config.excitonInfo.Q) == 0);
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("Exciton file parsing - anisotropic", "[excitonfile_parsing_anisotropic]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing anisotropic exciton file parsing... ";
+    std::cout << std::setw(50) << std::left << "Testing anisotropic exciton file parsing... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     std::string excitonconfig = "./data/hBN_anisotropic.txt";
-    xatu::ExcitonConfiguration config = xatu::ExcitonConfiguration(excitonconfig);
+    xatu::ExcitonConfiguration config(excitonconfig);
 
     std::string expectedName = "hBN_ani";
     int expectedNcell = 30;
@@ -295,21 +282,19 @@ TEST_CASE("Exciton file parsing - anisotropic", "[excitonfile_parsing_anisotropi
     }
     REQUIRE(xatu::array2hash(config.excitonInfo.Q) == 0);
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
     
 TEST_CASE("TB hBN energies (full diagonalization)", "[tb-hBN-fulldiag]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN energies (fulldiag)... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN energies (fulldiag)... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
     int nstates = 3;
 
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10});
 
@@ -326,22 +311,19 @@ TEST_CASE("TB hBN energies (full diagonalization)", "[tb-hBN-fulldiag]"){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-4));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("TB hBN energies (davidson)", "[tb-hBN-davidson]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN energies (Davidson)... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN energies (Davidson)... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
     int nstates = 3;
 
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10});
 
@@ -358,22 +340,19 @@ TEST_CASE("TB hBN energies (davidson)", "[tb-hBN-davidson]"){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-4));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("TB hBN energies (Lanczos)", "[hBN-lanczos]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN energies (Lanczos)... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN energies (Lanczos)... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
     int nstates = 3;
 
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10});
 
@@ -390,22 +369,19 @@ TEST_CASE("TB hBN energies (Lanczos)", "[hBN-lanczos]"){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-4));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("TB hBN energies (reciprocal)", "[tb-hBN-reciprocal]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN energies (reciprocal)... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN energies (reciprocal)... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
     int nstates = 3;
 
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10});
     exciton.setMode("reciprocalspace");
@@ -425,22 +401,19 @@ TEST_CASE("TB hBN energies (reciprocal)", "[tb-hBN-reciprocal]"){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-4));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("TB hBN reciprocal w.f.", "[tb-hBN-kwf]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN reciprocal w.f... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN reciprocal w.f... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
     int nstates = 2;
 
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10});
 
@@ -468,14 +441,12 @@ TEST_CASE("TB hBN reciprocal w.f.", "[tb-hBN-kwf]"){
     double expectedKwfHash = 1.086145105;
     REQUIRE_THAT(kwfHash, Catch::Matchers::WithinAbs(expectedKwfHash, 1E-5));
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("TB hBN real-space w.f.", "[tb-hBN-rswf]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN real-space w.f... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN real-space w.f... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
@@ -484,7 +455,7 @@ TEST_CASE("TB hBN real-space w.f.", "[tb-hBN-rswf]"){
     arma::rowvec holeCell = {0, 0, 0};
 
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10});
 
@@ -516,21 +487,19 @@ TEST_CASE("TB hBN real-space w.f.", "[tb-hBN-rswf]"){
     double expectedRSwfHash = 3.4185866144;
     REQUIRE_THAT(rswfHash, Catch::Matchers::WithinAbs(expectedRSwfHash, 1E-5));
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("TB hBN absorption", "[tb-hBN-kubo]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN conductivity... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN conductivity... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
     int nstates = 2;
 
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10});
 
@@ -546,21 +515,19 @@ TEST_CASE("TB hBN absorption", "[tb-hBN-kubo]"){
     double expectedTotalOscillator = 47.4140064;
     REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-6));
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("TB hBN energies (spinful)", "[tb-hBN-spinful]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN spinful... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN spinful... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
     int nstates = 12;
 
     std::string modelfile = "../examples/material_models/hBN_spinful.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 2, 0, {1, 1, 10});
 
@@ -577,22 +544,19 @@ TEST_CASE("TB hBN energies (spinful)", "[tb-hBN-spinful]"){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-4));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
     
 TEST_CASE("TB hBN spin", "[tb-hBN-spin]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN spin... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN spin... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 16;
     int nstates = 4;
 
     std::string modelfile = "../examples/material_models/hBN_spinful.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 2, 0, {1, 1, 10});
     
@@ -611,14 +575,12 @@ TEST_CASE("TB hBN spin", "[tb-hBN-spin]"){
         REQUIRE_THAT(std::abs(spin(2)), Catch::Matchers::WithinAbs(0.5, 1E-2));
     }
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("DFT hBN", "[dft-hBN]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing DFT hBN... ";
+    std::cout << std::setw(50) << std::left << "Testing DFT hBN... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
@@ -628,7 +590,7 @@ TEST_CASE("DFT hBN", "[dft-hBN]"){
     arma::rowvec holeCell = {0, 0, 0};
 
     std::string modelfile = "../examples/material_models/DFT/hBN_base_HSE06.outp";
-    xatu::CRYSTALConfiguration config = xatu::CRYSTALConfiguration(modelfile, 100);
+    xatu::CRYSTALConfiguration config(modelfile, 100);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10});
     exciton.system->setAU(true);
@@ -692,14 +654,12 @@ TEST_CASE("DFT hBN", "[dft-hBN]"){
     double expectedRSwfHash = 83.2242560463;
     REQUIRE_THAT(rswfHash, Catch::Matchers::WithinAbs(expectedRSwfHash, 1E-5));
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("Wannier hBN", "[w90-hBN]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing Wannierized hBN... ";
+    std::cout << std::setw(50) << std::left << "Testing Wannierized hBN... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 30;
@@ -709,7 +669,7 @@ TEST_CASE("Wannier hBN", "[w90-hBN]"){
     arma::rowvec holeCell = {0, 0, 0};
 
     std::string modelfile = "../examples/material_models/wannier/hBN_tb.dat";
-    xatu::Wannier90Configuration config = xatu::Wannier90Configuration(modelfile, 4);
+    xatu::Wannier90Configuration config(modelfile, 4);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10});
     exciton.system->setAU(true);
@@ -782,21 +742,19 @@ TEST_CASE("Wannier hBN", "[w90-hBN]"){
     double expectedRSwfHash = 1.003540;
     REQUIRE_THAT(rswfHash, Catch::Matchers::WithinAbs(expectedRSwfHash, 1E-5));
 
-    std::cout.clear();
-    std::cout << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("TB hBN-ani energies (full diagonalization)", "[tb-hBN-ani-fulldiag]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN-ani energies (fulldiag)... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN-ani energies (fulldiag)... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
     int nstates = 3;
 
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10, 25, 35});
 
@@ -815,22 +773,19 @@ TEST_CASE("TB hBN-ani energies (full diagonalization)", "[tb-hBN-ani-fulldiag]")
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-4));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("TB hBN absorption - anisotropic", "[tb-hBN-kubo-ani]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing TB hBN anisotropic conductivity... ";
+    std::cout << std::setw(50) << std::left << "Testing TB hBN anisotropic conductivity... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 20;
     int nstates = 2;
 
     std::string modelfile = "../examples/material_models/hBN.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 1, 0, {1, 1, 10, 25, 35});
 
@@ -846,21 +801,19 @@ TEST_CASE("TB hBN absorption - anisotropic", "[tb-hBN-kubo-ani]"){
     double expectedTotalOscillator = 47.4140063784;
     REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-7));
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("MoS2 energies", "[MoS2-energies]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing MoS2 energies... ";
+    std::cout << std::setw(50) << std::left << "Testing MoS2 energies... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 12;
     int nstates = 2;
 
     std::string modelfile = "../examples/material_models/MoS2.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 2, 0, {1., 4., 13.55});
 
@@ -877,22 +830,19 @@ TEST_CASE("MoS2 energies", "[MoS2-energies]"){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-4));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("MoS2 reciprocal w.f.", "[MoS2-kwf]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing MoS2 reciprocal w.f... ";
+    std::cout << std::setw(50) << std::left << "Testing MoS2 reciprocal w.f... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 12;
     int nstates = 2;
 
     std::string modelfile = "../examples/material_models/MoS2.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 2, 0, {1., 4., 13.55});
 
@@ -920,14 +870,12 @@ TEST_CASE("MoS2 reciprocal w.f.", "[MoS2-kwf]"){
     double expectedKwfHash = 1.1814790902;
     REQUIRE_THAT(kwfHash, Catch::Matchers::WithinAbs(expectedKwfHash, 1E-5));
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("MoS2 spin", "[MoS2-spin]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing MoS2 spin... ";
+    std::cout << std::setw(50) << std::left << "Testing MoS2 spin... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 12;
@@ -935,7 +883,7 @@ TEST_CASE("MoS2 spin", "[MoS2-spin]"){
     int factor = 2;
 
     std::string modelfile = "../examples/material_models/MoS2.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 2, 0, {1., 4., 13.55});
 
@@ -959,21 +907,19 @@ TEST_CASE("MoS2 spin", "[MoS2-spin]"){
         }
     }
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("MoS2 exciton bands", "[MoS2-Q]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing MoS2 exciton bands... ";
+    std::cout << std::setw(50) << std::left << "Testing MoS2 exciton bands... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 12;
     int nstates = 2;
 
     std::string modelfile = "../examples/material_models/MoS2.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
     
     arma::vec Q_values = {-0.1, -0.05, 0.0, 0.05, 0.1};
     arma::rowvec Q = {0., 0., 0.};
@@ -1002,15 +948,12 @@ TEST_CASE("MoS2 exciton bands", "[MoS2-Q]"){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-5));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("MoS2 exchange", "[MoS2-exchange]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing MoS2 with exchange... ";
+    std::cout << std::setw(50) << std::left << "Testing MoS2 with exchange... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 12;
@@ -1018,7 +961,7 @@ TEST_CASE("MoS2 exchange", "[MoS2-exchange]"){
     arma::rowvec Q = {0., 0.1, 0.};
 
     std::string modelfile = "../examples/material_models/MoS2.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 2, 0, {1., 4., 13.55}, Q);
     exciton.setExchange(true);
@@ -1037,15 +980,12 @@ TEST_CASE("MoS2 exchange", "[MoS2-exchange]"){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-5));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("MoS2 reduced BZ", "[MoS2-reducedBZ]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing MoS2 with reduced BZ... ";
+    std::cout << std::setw(50) << std::left << "Testing MoS2 with reduced BZ... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 12;
@@ -1053,7 +993,7 @@ TEST_CASE("MoS2 reduced BZ", "[MoS2-reducedBZ]"){
     int factor = 2;
 
     std::string modelfile = "../examples/material_models/MoS2.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 2, 0, {1., 4., 13.55});
 
@@ -1074,22 +1014,19 @@ TEST_CASE("MoS2 reduced BZ", "[MoS2-reducedBZ]"){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-4));
         REQUIRE(energies[i][1] == expectedEnergies[i][1]);
     }
-
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 
 TEST_CASE("MoS2 absorption", "[MoS2-kubo]"){
 
     std::cout.clear();
-    std::cout << std::setw(40) << std::left << "Testing MoS2 conductivity... ";
+    std::cout << std::setw(50) << std::left << "Testing MoS2 conductivity... " << std::endl;
     std::cout.setstate(std::ios_base::failbit);
 
     int ncell = 12;
     int nstates = 2;
 
     std::string modelfile = "../examples/material_models/MoS2.model";    
-    xatu::SystemConfiguration config = xatu::SystemConfiguration(modelfile);
+    xatu::SystemConfiguration config(modelfile);
 
     xatu::ExcitonTB exciton = xatu::ExcitonTB(config, ncell, 2, 0, {1., 4., 13.55});
 
@@ -1105,7 +1042,5 @@ TEST_CASE("MoS2 absorption", "[MoS2-kubo]"){
     double expectedTotalOscillator = 37.2822837;
     REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-6));
 
-    std::cout.clear();
-    std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
 }
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -543,8 +543,8 @@ TEST_CASE("TB hBN absorption", "[tb-hBN-kubo]"){
     arma::mat norm_vme_ex = arma::square(arma::abs(vme_ex));
     double cum_norm_vme_ex = arma::accu(norm_vme_ex);
 
-    double expectedTotalOscillator = 47.4140063784;
-    REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-7));
+    double expectedTotalOscillator = 47.4140064;
+    REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-6));
 
     std::cout.clear();
     std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;
@@ -734,8 +734,8 @@ TEST_CASE("Wannier hBN", "[w90-hBN]"){
     arma::mat norm_vme_ex = arma::square(arma::abs(vme_ex));
     double cum_norm_vme_ex = arma::accu(norm_vme_ex);
 
-    double expectedTotalOscillator = 103.0312591808;
-    REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-7));
+    double expectedTotalOscillator = 103.0325881;
+    REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-6));
 
     // Check reciprocal w.f.
     int nbandsCombinations = exciton.conductionBands.n_elem * exciton.valenceBands.n_elem;
@@ -809,7 +809,7 @@ TEST_CASE("TB hBN-ani energies (full diagonalization)", "[tb-hBN-ani-fulldiag]")
     
     std::vector<std::vector<double>> expectedEnergies = {{6.428535, 1}, 
                                                          {6.456359, 1},
-                                                         {6.731320, 1}};
+                                                         {6.732466, 1}};
 
     for(uint i = 0; i < energies.size(); i++){
         REQUIRE_THAT(energies[i][0], Catch::Matchers::WithinAbs(expectedEnergies[i][0], 1E-4));
@@ -1102,8 +1102,8 @@ TEST_CASE("MoS2 absorption", "[MoS2-kubo]"){
     arma::mat norm_vme_ex = arma::square(arma::abs(vme_ex));
     double cum_norm_vme_ex = arma::accu(norm_vme_ex);
 
-    double expectedTotalOscillator = 37.2792093358;
-    REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-7));
+    double expectedTotalOscillator = 37.2822837;
+    REQUIRE_THAT(cum_norm_vme_ex, Catch::Matchers::WithinAbs(expectedTotalOscillator, 1E-6));
 
     std::cout.clear();
     std::cout << std::setw(40) << "\033[1;32m Success \033[0m" << std::endl;

--- a/utility/wannier2xatu/utils.f90
+++ b/utility/wannier2xatu/utils.f90
@@ -56,8 +56,10 @@ module utils
                     enddo
                 end if
                 
-                ! Last line of degenerecences
-                read(fp, *) Degen((i - 1)*15 + 1:(i - 1)*15 + MOD(nFock, 15))  
+                ! Read the last partial line only if needed
+                if (MOD(nFock, 15) .ne. 0) then
+                    read(fp, *) Degen((nFock - MOD(nFock, 15) + 1):nFock)
+                endif 
                 read(fp, *)
                 
                 ! begin hamiltonian read


### PR DESCRIPTION
### 1. Anisotropic Keldysh Potential
- Support for anisotropic screening lengths in the Keldysh interaction.
- Users can now specify different screening lengths for the in-plane (x, y) and out-of-plane (z) directions. See documentation on the exciton configuration file.

### 2. Out-of-Plane Excitonic Absorption
- Implementation of out-of-plane optical absorption calculations using excitonic states bases on Quintela 2023

### 3. `.eigval` Output Format
- Eigenvalues are now written in a single column (instead of a single line) to improve clarity and facilitate post-processing.

### 4. Oscillator Strength Output
- The absorption output (`-a` / `--absorption`) now includes oscillator strengths written separately in a dedicated file.
- Output file follows the naming pattern: `<prefix>_ex_osc.dat`.

### 5. Generalization of `conductivity.py`
- `conductivity.py` script has been refactored for improved usability.
- Usage:
  ```bash
  python conductivity.py <ex_spectrum> <sp_spectrum> [oscillators_file]